### PR TITLE
Fix for host header for non-empty port in S3Request.java

### DIFF
--- a/src/main/java/am/ik/s3/S3Request.java
+++ b/src/main/java/am/ik/s3/S3Request.java
@@ -88,7 +88,8 @@ public final class S3Request {
 		AmzDate amzDate = new AmzDate(this.clock.instant());
 		String contentSha256 = content == null ? UNSIGNED_PAYLOAD : encodeHex(sha256Hash(content.body()));
 		TreeMap<String, String> headers = new TreeMap<>();
-		headers.put(HttpHeaders.HOST, this.endpoint.getHost());
+		String portPartOfHost = this.endpoint.getPort() == -1 ? "" : ":" + this.endpoint.getPort();
+		headers.put(HttpHeaders.HOST, this.endpoint.getHost() + portPartOfHost);
 		headers.put(AmzHttpHeaders.X_AMZ_CONTENT_SHA256, contentSha256);
 		headers.put(AmzHttpHeaders.X_AMZ_DATE, amzDate.date());
 		if (content != null && content.body() != null) {

--- a/src/main/java/am/ik/s3/S3Request.java
+++ b/src/main/java/am/ik/s3/S3Request.java
@@ -88,8 +88,11 @@ public final class S3Request {
 		AmzDate amzDate = new AmzDate(this.clock.instant());
 		String contentSha256 = content == null ? UNSIGNED_PAYLOAD : encodeHex(sha256Hash(content.body()));
 		TreeMap<String, String> headers = new TreeMap<>();
-		String portPartOfHost = this.endpoint.getPort() == -1 ? "" : ":" + this.endpoint.getPort();
-		headers.put(HttpHeaders.HOST, this.endpoint.getHost() + portPartOfHost);
+		StringBuilder host = new StringBuilder(this.endpoint.getHost());
+		if (this.endpoint.getPort() != -1) {
+			host.append(":").append(this.endpoint.getPort());
+		}
+		headers.put(HttpHeaders.HOST, host.toString());
 		headers.put(AmzHttpHeaders.X_AMZ_CONTENT_SHA256, contentSha256);
 		headers.put(AmzHttpHeaders.X_AMZ_DATE, amzDate.date());
 		if (content != null && content.body() != null) {


### PR DESCRIPTION
The host header must include the port. When calculating the hash, S3 includes the port as per http spec in the host header. Tested against quay.io/minio/minio:RELEASE.2024-03-30T09-41-56Z