### PR TITLE
Add presigned URL and POST form support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This library provides two ways to interact with S3:
 The `S3Client` provides a modern, fluent API for S3 operations with method chaining.
 
 ```java
+import java.time.Duration;
+import am.ik.s3.*;
+
 // Create client with default RestClient configuration
 S3Client client = S3Client.builder()
     .endpoint("https://s3.amazonaws.com")
@@ -53,6 +56,32 @@ String content = client.bucket("my-bucket").object("hello.txt").get();
 System.out.println("Content: " + content); // Content: Hello World!
 
 byte[] imageData = client.bucket("my-bucket").object("test.png").getAsBytes();
+
+// Generate presigned URLs for secure access
+PresignedUrl getUrl = client.bucket("my-bucket")
+    .object("hello.txt")
+    .presignedUrl()
+    .expiration(Duration.ofHours(2))
+    .forGet();
+System.out.println("Get URL: " + getUrl.url());
+
+PresignedUrl putUrl = client.bucket("my-bucket")
+    .object("upload.txt")
+    .presignedUrl()
+    .expiration(Duration.ofMinutes(15))
+    .contentType("text/plain")
+    .forPut();
+System.out.println("Put URL: " + putUrl.url());
+
+// Generate presigned POST form for browser uploads
+PresignedPostForm postForm = client.bucket("my-bucket")
+    .object("uploads/${filename}")
+    .presignedPostForm()
+    .expiration(Duration.ofHours(1))
+    .maxFileSize(DataSize.ofMegabytes(10))
+    .generate();
+System.out.println("POST URL: " + postForm.url());
+System.out.println("Form fields: " + postForm.formFields());
 
 // Clean up
 client.bucket("my-bucket").object("hello.txt").delete();
@@ -153,6 +182,35 @@ S3Request deleteBucketRequest = s3Request().endpoint(endpoint)
 	.path(b -> b.bucket(bucket))
 	.build();
 restTemplate.exchange(deleteBucketRequest.toEntityBuilder().build(), Void.class);
+
+// Generate presigned URL for GET operation
+S3Request getRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.GET)
+	.path(b -> b.bucket(bucket).key("hello.txt"))
+	.build();
+
+PresignedUrl presignedUrl = getRequest.generatePresignedUrl(Duration.ofHours(1));
+System.out.println("Presigned URL: " + presignedUrl.url());
+
+// Use the presigned URL with RestTemplate
+HttpHeaders httpHeaders = new HttpHeaders();
+presignedUrl.requiredHeaders().forEach(httpHeaders::add);
+HttpEntity<Void> httpEntity = new HttpEntity<>(httpHeaders);
+String content = restTemplate.exchange(presignedUrl.url(), HttpMethod.GET, httpEntity, String.class).getBody();
+
+// Generate presigned POST form for browser uploads
+S3ClientConfiguration config = new S3ClientConfiguration(endpoint, region, accessKeyId, secretAccessKey);
+PresignedPostForm postForm = PresignedPostForm.builder(config, bucket, "uploads/file.txt")
+	.expiration(Duration.ofHours(1))
+	.maxFileSize(DataSize.ofMegabytes(10))
+	.field("Content-Type", "text/plain")
+	.generate();
+
+System.out.println("POST URL: " + postForm.url());
+System.out.println("Form fields: " + postForm.formFields());
 ```
 
 ## Examples with `RestClient` (Low-level API)
@@ -268,6 +326,36 @@ restClient.delete()
 	.headers(deleteBucketRequest.headers())
 	.retrieve()
 	.toBodilessEntity();
+
+// Generate presigned URL for GET operation
+S3Request getRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.GET)
+	.path(b -> b.bucket(bucket).key("hello.txt"))
+	.build();
+
+PresignedUrl presignedUrl = getRequest.generatePresignedUrl(Duration.ofHours(1));
+System.out.println("Presigned URL: " + presignedUrl.url());
+
+// Use the presigned URL
+String content = restClient.get()
+	.uri(presignedUrl.url())
+	.headers(presignedUrl.headers())
+	.retrieve()
+	.body(String.class);
+
+// Generate presigned POST form for browser uploads
+S3ClientConfiguration config = new S3ClientConfiguration(endpoint, region, accessKeyId, secretAccessKey);
+PresignedPostForm postForm = PresignedPostForm.builder(config, bucket, "uploads/file.txt")
+	.expiration(Duration.ofHours(1))
+	.maxFileSize(DataSize.ofMegabytes(10))
+	.field("Content-Type", "text/plain")
+	.generate();
+
+System.out.println("POST URL: " + postForm.url());
+System.out.println("Form fields: " + postForm.formFields());
 ```
 
 ## API Overview
@@ -298,6 +386,24 @@ restClient.delete()
 - `.get()` - Download as string
 - `.getAsBytes()` - Download as byte array
 - `.delete()` - Delete the object
+
+#### Presigned URL Operations
+- `.presignedUrl()` - Create a presigned URL builder
+- `.expiration(Duration)` - Set expiration time for the URL
+- `.contentType(String)` - Set content type for PUT operations
+- `.header(String, String)` - Add custom headers
+- `.parameter(String, String)` - Add query parameters
+- `.forGet()` - Generate presigned URL for GET operation
+- `.forPut()` - Generate presigned URL for PUT operation
+- `.forDelete()` - Generate presigned URL for DELETE operation
+
+#### Presigned POST Form Operations
+- `.presignedPostForm()` - Create a presigned POST form builder
+- `.expiration(Duration)` - Set expiration time for the form
+- `.maxFileSize(DataSize)` - Set maximum file size in bytes
+- `.field(String, String)` - Add form field
+- `.condition(String)` - Add policy condition
+- `.generate()` - Generate the presigned POST form
 
 ### When to Use Which API
 

--- a/src/main/java/am/ik/s3/PresignedPostForm.java
+++ b/src/main/java/am/ik/s3/PresignedPostForm.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Represents a presigned POST form for direct browser uploads to S3.
+ *
+ * @since 0.3.0
+ */
+public record PresignedPostForm(URI url, Map<String, String> formFields, Instant expiresAt, List<String> conditions) {
+
+	/**
+	 * Creates a new builder for presigned POST forms.
+	 * @param configuration the S3 client configuration
+	 * @param bucketName the bucket name
+	 * @param objectKey the object key
+	 * @return a new builder instance
+	 */
+	public static Builder builder(S3ClientConfiguration configuration, String bucketName, String objectKey) {
+		return new Builder(configuration, bucketName, objectKey);
+	}
+
+	/**
+	 * Builder for generating presigned POST forms for direct browser uploads to S3.
+	 *
+	 * @since 0.3.0
+	 */
+	public static class Builder {
+
+		private final S3ClientConfiguration configuration;
+
+		private final String bucketName;
+
+		private final String objectKey;
+
+		private Duration expiration = Duration.ofHours(1);
+
+		private final Map<String, String> formFields = new LinkedHashMap<>();
+
+		private final List<String> conditions = new ArrayList<>();
+
+		private Long maxFileSize;
+
+		private Builder(S3ClientConfiguration configuration, String bucketName, String objectKey) {
+			this.configuration = configuration;
+			this.bucketName = bucketName;
+			this.objectKey = objectKey;
+		}
+
+		/**
+		 * Sets the expiration duration for the presigned POST form.
+		 * @param expiration the duration until the form expires
+		 * @return this builder
+		 */
+		public Builder expiration(Duration expiration) {
+			this.expiration = expiration;
+			return this;
+		}
+
+		/**
+		 * Sets the maximum file size for uploads.
+		 * @param maxFileSize the maximum file size in bytes
+		 * @return this builder
+		 */
+		public Builder maxFileSize(long maxFileSize) {
+			this.maxFileSize = maxFileSize;
+			return this;
+		}
+
+		/**
+		 * Sets the maximum file size for uploads.
+		 * @param maxFileSize the maximum file size as DataSize
+		 * @return this builder
+		 */
+		public Builder maxFileSize(DataSize maxFileSize) {
+			this.maxFileSize = maxFileSize.toBytes();
+			return this;
+		}
+
+		/**
+		 * Adds a form field to be included in the POST form.
+		 * @param name the field name
+		 * @param value the field value
+		 * @return this builder
+		 */
+		public Builder field(String name, String value) {
+			this.formFields.put(name, value);
+			return this;
+		}
+
+		/**
+		 * Adds a condition to the policy.
+		 * @param condition the condition string
+		 * @return this builder
+		 */
+		public Builder condition(String condition) {
+			this.conditions.add(condition);
+			return this;
+		}
+
+		/**
+		 * Generates the presigned POST form.
+		 * @return the presigned POST form
+		 */
+		public PresignedPostForm generate() {
+			Instant expirationTime = Instant.now().plus(expiration);
+			AmzDate amzDate = new AmzDate(Instant.now());
+
+			URI url = UriComponentsBuilder.fromUri(configuration.endpoint()).path("/" + bucketName).build().toUri();
+
+			String credentialScope = "%s/%s/s3/aws4_request".formatted(amzDate.yymmdd(), configuration.region());
+			String credential = "%s/%s".formatted(configuration.accessKeyId(), credentialScope);
+
+			Map<String, String> fields = new LinkedHashMap<>();
+			fields.put("key", objectKey);
+			fields.put("bucket", bucketName);
+			fields.put("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+			fields.put("X-Amz-Credential", credential);
+			fields.put("X-Amz-Date", amzDate.date());
+			fields.putAll(formFields);
+
+			List<String> policyConditions = new ArrayList<>();
+			policyConditions.add("{\"bucket\": \"" + bucketName + "\"}");
+			policyConditions.add("{\"key\": \"" + objectKey + "\"}");
+			policyConditions.add("{\"X-Amz-Algorithm\": \"AWS4-HMAC-SHA256\"}");
+			policyConditions.add("{\"X-Amz-Credential\": \"" + credential + "\"}");
+			policyConditions.add("{\"X-Amz-Date\": \"" + amzDate.date() + "\"}");
+
+			// Add conditions for form fields
+			formFields.forEach((key, value) -> {
+				policyConditions.add("{\"" + key + "\": \"" + value + "\"}");
+			});
+
+			if (maxFileSize != null) {
+				policyConditions.add("[\"content-length-range\", 0, " + maxFileSize + "]");
+			}
+
+			policyConditions.addAll(conditions);
+
+			String policy = "{\n" + "  \"expiration\": \"" + expirationTime.toString() + "\",\n"
+					+ "  \"conditions\": [\n    " + String.join(",\n    ", policyConditions) + "\n  ]\n" + "}";
+
+			String encodedPolicy = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+			fields.put("policy", encodedPolicy);
+
+			String signature = generateSignature(encodedPolicy, amzDate);
+			fields.put("X-Amz-Signature", signature);
+
+			return new PresignedPostForm(url, fields, expirationTime, conditions);
+		}
+
+		private String generateSignature(String policy, AmzDate amzDate) {
+			try {
+				byte[] kSecret = ("AWS4" + configuration.secretAccessKey()).getBytes(StandardCharsets.UTF_8);
+				byte[] kDate = S3RequestSigningUtils.hmacSHA256(amzDate.yymmdd(), kSecret);
+				byte[] kRegion = S3RequestSigningUtils.hmacSHA256(configuration.region(), kDate);
+				byte[] kService = S3RequestSigningUtils.hmacSHA256("s3", kRegion);
+				byte[] kSigning = S3RequestSigningUtils.hmacSHA256("aws4_request", kService);
+				byte[] signature = S3RequestSigningUtils.hmacSHA256(policy, kSigning);
+				return S3RequestSigningUtils.encodeHex(signature);
+			}
+			catch (Exception e) {
+				throw new RuntimeException("Failed to generate signature", e);
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/am/ik/s3/PresignedUrl.java
+++ b/src/main/java/am/ik/s3/PresignedUrl.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import static am.ik.s3.S3RequestBuilder.s3Request;
+
+/**
+ * Represents a presigned URL for S3 operations with expiration information.
+ *
+ * @since 0.3.0
+ */
+public record PresignedUrl(URI url, Instant expiresAt, Map<String, String> requiredHeaders) {
+
+	/**
+	 * Checks if this presigned URL has expired using the system default clock.
+	 * @return true if the URL has expired, false otherwise
+	 */
+	public boolean isExpired() {
+		return isExpired(Clock.systemUTC());
+	}
+
+	/**
+	 * Checks if this presigned URL has expired using the specified clock.
+	 * @param clock the clock to use for checking expiration
+	 * @return true if the URL has expired, false otherwise
+	 */
+	public boolean isExpired(Clock clock) {
+		return clock.instant().isAfter(expiresAt);
+	}
+
+	/**
+	 * Returns a Consumer that adds required headers for this presigned URL. This is
+	 * convenient for use with RestClient's headers() method.
+	 * @return a Consumer that adds required headers to HttpHeaders
+	 */
+	public Consumer<HttpHeaders> headers() {
+		return headers -> requiredHeaders.forEach(headers::add);
+	}
+
+	/**
+	 * Creates a new builder for presigned URLs.
+	 * @param configuration the S3 client configuration
+	 * @param bucketName the bucket name
+	 * @param objectKey the object key
+	 * @return a new builder instance
+	 */
+	public static Builder builder(S3ClientConfiguration configuration, String bucketName, String objectKey) {
+		return new Builder(configuration, bucketName, objectKey);
+	}
+
+	/**
+	 * Builder for generating presigned URLs for S3 operations.
+	 *
+	 * @since 0.3.0
+	 */
+	public static class Builder {
+
+		private final S3ClientConfiguration configuration;
+
+		private final String bucketName;
+
+		private final String objectKey;
+
+		private Duration expiration = Duration.ofHours(1);
+
+		private final Map<String, String> requestHeaders = new HashMap<>();
+
+		private final Map<String, String> requestParameters = new HashMap<>();
+
+		private Builder(S3ClientConfiguration configuration, String bucketName, String objectKey) {
+			this.configuration = configuration;
+			this.bucketName = bucketName;
+			this.objectKey = objectKey;
+		}
+
+		/**
+		 * Sets the expiration duration for the presigned URL.
+		 * @param expiration the duration until the URL expires
+		 * @return this builder
+		 */
+		public Builder expiration(Duration expiration) {
+			this.expiration = expiration;
+			return this;
+		}
+
+		/**
+		 * Adds a request header to be included in the presigned URL.
+		 * @param name the header name
+		 * @param value the header value
+		 * @return this builder
+		 */
+		public Builder header(String name, String value) {
+			this.requestHeaders.put(name, value);
+			return this;
+		}
+
+		/**
+		 * Adds a request parameter to be included in the presigned URL.
+		 * @param name the parameter name
+		 * @param value the parameter value
+		 * @return this builder
+		 */
+		public Builder parameter(String name, String value) {
+			this.requestParameters.put(name, value);
+			return this;
+		}
+
+		/**
+		 * Sets the content type for the presigned URL (useful for PUT operations).
+		 * @param contentType the content type
+		 * @return this builder
+		 */
+		public Builder contentType(String contentType) {
+			this.requestHeaders.put("Content-Type", contentType);
+			return this;
+		}
+
+		/**
+		 * Sets the content type for the presigned URL (useful for PUT operations).
+		 * @param mediaType the media type
+		 * @return this builder
+		 */
+		public Builder contentType(MediaType mediaType) {
+			return contentType(mediaType.toString());
+		}
+
+		/**
+		 * Generates a presigned URL for GET operation.
+		 * @return the presigned URL
+		 */
+		public PresignedUrl forGet() {
+			return generatePresignedUrl(HttpMethod.GET);
+		}
+
+		/**
+		 * Generates a presigned URL for PUT operation.
+		 * @return the presigned URL
+		 */
+		public PresignedUrl forPut() {
+			return generatePresignedUrl(HttpMethod.PUT);
+		}
+
+		/**
+		 * Generates a presigned URL for DELETE operation.
+		 * @return the presigned URL
+		 */
+		public PresignedUrl forDelete() {
+			return generatePresignedUrl(HttpMethod.DELETE);
+		}
+
+		private PresignedUrl generatePresignedUrl(HttpMethod method) {
+			String queryString = requestParameters.isEmpty() ? null
+					: requestParameters.entrySet()
+						.stream()
+						.map(e -> e.getKey() + "=" + e.getValue())
+						.reduce((a, b) -> a + "&" + b)
+						.orElse("");
+
+			S3Request request = s3Request().endpoint(configuration.endpoint())
+				.region(configuration.region())
+				.accessKeyId(configuration.accessKeyId())
+				.secretAccessKey(configuration.secretAccessKey())
+				.method(method)
+				.path(b -> b.bucket(bucketName).key(objectKey))
+				.canonicalQueryString(queryString)
+				.build();
+
+			return request.generatePresignedUrl(expiration, requestHeaders.isEmpty() ? null : requestHeaders);
+		}
+
+	}
+
+}

--- a/src/main/java/am/ik/s3/S3OperationBuilder.java
+++ b/src/main/java/am/ik/s3/S3OperationBuilder.java
@@ -260,6 +260,24 @@ public class S3OperationBuilder {
 			return true;
 		}
 
+		/**
+		 * Creates a presigned URL builder for this object.
+		 * @return a new PresignedUrl.Builder instance
+		 * @since 0.3.0
+		 */
+		public PresignedUrl.Builder presignedUrl() {
+			return PresignedUrl.builder(configuration, bucketName, objectKey);
+		}
+
+		/**
+		 * Creates a presigned POST form builder for this object.
+		 * @return a new PresignedPostForm.Builder instance
+		 * @since 0.3.0
+		 */
+		public PresignedPostForm.Builder presignedPostForm() {
+			return PresignedPostForm.builder(configuration, bucketName, objectKey);
+		}
+
 	}
 
 }

--- a/src/main/java/am/ik/s3/S3Request.java
+++ b/src/main/java/am/ik/s3/S3Request.java
@@ -16,20 +16,17 @@
 package am.ik.s3;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
-import java.util.HexFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 
 import org.jilt.Builder;
 import org.jilt.BuilderStyle;
@@ -104,7 +101,8 @@ public final class S3Request {
 
 	private void init() {
 		AmzDate amzDate = new AmzDate(this.clock.instant());
-		String contentSha256 = content == null ? UNSIGNED_PAYLOAD : encodeHex(sha256Hash(content.body()));
+		String contentSha256 = content == null ? UNSIGNED_PAYLOAD
+				: S3RequestSigningUtils.encodeHex(S3RequestSigningUtils.sha256Hash(content.body()));
 		TreeMap<String, String> headers = new TreeMap<>();
 		StringBuilder host = new StringBuilder(this.endpoint.getHost());
 		if (this.endpoint.getPort() != -1) {
@@ -168,7 +166,8 @@ public final class S3Request {
 				signedHeaders, payloadHash);
 		// Step 2: Create a hash of the canonical request
 		// https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request-hash
-		String hashedCanonicalRequest = encodeHex(sha256Hash(canonicalRequest.getBytes(StandardCharsets.UTF_8)));
+		String hashedCanonicalRequest = S3RequestSigningUtils
+			.encodeHex(S3RequestSigningUtils.sha256Hash(canonicalRequest.getBytes(StandardCharsets.UTF_8)));
 		// Step 3: Create a string to sign
 		// https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-string-to-sign
 		String credentialScope = "%s/%s/s3/aws4_request".formatted(amzDate.yymmdd(), this.region);
@@ -186,43 +185,99 @@ public final class S3Request {
 
 	private String sign(String stringToSign, AmzDate amzDate) {
 		byte[] kSecret = ("AWS4" + this.secretAccessKey).getBytes(StandardCharsets.UTF_8);
-		byte[] kDate = hmacSHA256(amzDate.yymmdd(), kSecret);
-		byte[] kRegion = hmacSHA256(this.region, kDate);
-		byte[] kService = hmacSHA256("s3", kRegion);
-		byte[] kSigning = hmacSHA256("aws4_request", kService);
-		return encodeHex(hmacSHA256(stringToSign, kSigning));
+		byte[] kDate = S3RequestSigningUtils.hmacSHA256(amzDate.yymmdd(), kSecret);
+		byte[] kRegion = S3RequestSigningUtils.hmacSHA256(this.region, kDate);
+		byte[] kService = S3RequestSigningUtils.hmacSHA256("s3", kRegion);
+		byte[] kSigning = S3RequestSigningUtils.hmacSHA256("aws4_request", kService);
+		return S3RequestSigningUtils.encodeHex(S3RequestSigningUtils.hmacSHA256(stringToSign, kSigning));
 	}
 
-	private static byte[] sha256Hash(byte[] data) {
-		try {
-			MessageDigest md = MessageDigest.getInstance("SHA-256");
-			return md.digest(data);
-		}
-		catch (NoSuchAlgorithmException e) {
-			// should not happen
-			throw new IllegalStateException(e);
-		}
+	/**
+	 * Generates a presigned URL for this S3 request.
+	 * @param expiration the duration until the URL expires
+	 * @return a PresignedUrl containing the URL and expiration information
+	 * @since 0.3.0
+	 */
+	public PresignedUrl generatePresignedUrl(Duration expiration) {
+		return generatePresignedUrl(expiration, null);
 	}
 
-	private static byte[] hmacSHA256(String data, byte[] key) {
-		try {
-			Mac mac = Mac.getInstance("HmacSHA256");
-			mac.init(new SecretKeySpec(key, "HmacSHA256"));
-			return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+	/**
+	 * Generates a presigned URL for this S3 request with additional headers.
+	 * @param expiration the duration until the URL expires
+	 * @param additionalHeaders additional headers to include in the presigned URL
+	 * @return a PresignedUrl containing the URL and expiration information
+	 * @since 0.3.0
+	 */
+	public PresignedUrl generatePresignedUrl(Duration expiration, Map<String, String> additionalHeaders) {
+		Instant expirationTime = clock.instant().plus(expiration);
+		AmzDate amzDate = new AmzDate(clock.instant());
+		String credentialScope = "%s/%s/s3/aws4_request".formatted(amzDate.yymmdd(), this.region);
+		String credential = "%s/%s".formatted(this.accessKeyId, credentialScope);
+
+		TreeMap<String, String> queryParams = new TreeMap<>();
+		queryParams.put("X-Amz-Algorithm", AWS4_HMAC_SHA256);
+		queryParams.put("X-Amz-Credential", credential);
+		queryParams.put("X-Amz-Date", amzDate.date());
+		queryParams.put("X-Amz-Expires", String.valueOf(expiration.getSeconds()));
+		queryParams.put("X-Amz-SignedHeaders", "host");
+
+		if (!canonicalQueryString.isEmpty()) {
+			String[] pairs = canonicalQueryString.split("&");
+			for (String pair : pairs) {
+				String[] parts = pair.split("=", 2);
+				if (parts.length == 2) {
+					queryParams.put(parts[0], parts[1]);
+				}
+			}
 		}
-		catch (NoSuchAlgorithmException | InvalidKeyException e) {
-			// should not happen
-			throw new IllegalStateException(e);
+
+		TreeMap<String, String> headers = new TreeMap<>();
+		StringBuilder host = new StringBuilder(this.endpoint.getHost());
+		if (this.endpoint.getPort() != -1) {
+			host.append(":").append(this.endpoint.getPort());
 		}
+		headers.put(HttpHeaders.HOST, host.toString());
+
+		if (additionalHeaders != null) {
+			headers.putAll(additionalHeaders);
+			String signedHeaders = headers.keySet().stream().map(String::toLowerCase).collect(Collectors.joining(";"));
+			queryParams.put("X-Amz-SignedHeaders", signedHeaders);
+		}
+
+		String canonicalQueryStringForSigning = queryParams.entrySet()
+			.stream()
+			.map(e -> urlEncode(e.getKey()) + "=" + urlEncode(e.getValue()))
+			.collect(Collectors.joining("&"));
+
+		String canonicalHeaders = headers.entrySet()
+			.stream()
+			.map(e -> "%s:%s".formatted(e.getKey().toLowerCase(), e.getValue()))
+			.collect(Collectors.joining("\n")) + "\n";
+		String signedHeaders = headers.keySet().stream().map(String::toLowerCase).collect(Collectors.joining(";"));
+
+		String canonicalRequest = String.join("\n", method.name(), canonicalUri, canonicalQueryStringForSigning,
+				canonicalHeaders, signedHeaders, UNSIGNED_PAYLOAD);
+
+		String hashedCanonicalRequest = S3RequestSigningUtils
+			.encodeHex(S3RequestSigningUtils.sha256Hash(canonicalRequest.getBytes(StandardCharsets.UTF_8)));
+		String stringToSign = String.join("\n", AWS4_HMAC_SHA256, amzDate.date(), credentialScope,
+				hashedCanonicalRequest);
+		String signature = this.sign(stringToSign, amzDate);
+
+		queryParams.put("X-Amz-Signature", signature);
+
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUri(this.endpoint).path(canonicalUri);
+
+		queryParams.forEach(builder::queryParam);
+
+		URI presignedUri = builder.build().toUri();
+
+		return new PresignedUrl(presignedUri, expirationTime, additionalHeaders != null ? additionalHeaders : Map.of());
 	}
 
-	private static String encodeHex(byte[] data) {
-		HexFormat hex = HexFormat.of();
-		StringBuilder sb = new StringBuilder();
-		for (byte datum : data) {
-			sb.append(hex.toHexDigits(datum));
-		}
-		return sb.toString();
+	private static String urlEncode(String value) {
+		return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
 	}
 
 	@Override

--- a/src/main/java/am/ik/s3/S3RequestSigningUtils.java
+++ b/src/main/java/am/ik/s3/S3RequestSigningUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Utility class for AWS S3 request signing operations.
+ *
+ * @since 0.3.0
+ */
+final class S3RequestSigningUtils {
+
+	private S3RequestSigningUtils() {
+	}
+
+	/**
+	 * Computes HMAC-SHA256 of the given data using the given key.
+	 * @param data the data to sign
+	 * @param key the key to use for signing
+	 * @return the HMAC-SHA256 signature
+	 */
+	public static byte[] hmacSHA256(String data, byte[] key) {
+		try {
+			Mac mac = Mac.getInstance("HmacSHA256");
+			mac.init(new SecretKeySpec(key, "HmacSHA256"));
+			return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+		}
+		catch (NoSuchAlgorithmException | InvalidKeyException e) {
+			throw new IllegalStateException("Failed to compute HMAC-SHA256", e);
+		}
+	}
+
+	/**
+	 * Computes SHA-256 hash of the given data.
+	 * @param data the data to hash
+	 * @return the SHA-256 hash
+	 */
+	public static byte[] sha256Hash(byte[] data) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			return md.digest(data);
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("Failed to compute SHA-256", e);
+		}
+	}
+
+	/**
+	 * Encodes the given byte array as a lowercase hexadecimal string.
+	 * @param data the byte array to encode
+	 * @return the hexadecimal string representation
+	 */
+	public static String encodeHex(byte[] data) {
+		HexFormat hex = HexFormat.of();
+		StringBuilder sb = new StringBuilder();
+		for (byte datum : data) {
+			sb.append(hex.toHexDigits(datum));
+		}
+		return sb.toString();
+	}
+
+}

--- a/src/test/java/am/ik/s3/PresignedPostFormTest.java
+++ b/src/test/java/am/ik/s3/PresignedPostFormTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import java.net.URI;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PresignedPostFormTest {
+
+	private static final String ENDPOINT = "https://s3.amazonaws.com";
+
+	private static final String REGION = "us-east-1";
+
+	private static final String ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+
+	private static final String SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+	private static final String BUCKET = "test-bucket";
+
+	private static final String OBJECT_KEY = "uploads/test-file.txt";
+
+	@Test
+	void testPresignedPostFormGeneration() {
+		S3ClientConfiguration config = new S3ClientConfiguration(URI.create(ENDPOINT), REGION, ACCESS_KEY_ID,
+				SECRET_ACCESS_KEY);
+		S3Client client = S3Client.builder()
+			.endpoint(ENDPOINT)
+			.region(REGION)
+			.credentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY)
+			.build();
+
+		PresignedPostForm postForm = client.bucket(BUCKET)
+			.object(OBJECT_KEY)
+			.presignedPostForm()
+			.expiration(Duration.ofHours(1))
+			.maxFileSize(10 * 1024 * 1024) // 10MB
+			.generate();
+
+		assertThat(postForm.url()).isEqualTo(URI.create("https://s3.amazonaws.com/test-bucket"));
+		assertThat(postForm.formFields()).containsKey("key");
+		assertThat(postForm.formFields()).containsKey("bucket");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Algorithm");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Credential");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Date");
+		assertThat(postForm.formFields()).containsKey("policy");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Signature");
+		assertThat(postForm.formFields()).containsValue(OBJECT_KEY);
+		assertThat(postForm.formFields()).containsValue(BUCKET);
+		assertThat(postForm.formFields()).containsValue("AWS4-HMAC-SHA256");
+	}
+
+	@Test
+	void testPresignedPostFormWithCustomFields() {
+		S3ClientConfiguration config = new S3ClientConfiguration(URI.create(ENDPOINT), REGION, ACCESS_KEY_ID,
+				SECRET_ACCESS_KEY);
+		S3Client client = S3Client.builder()
+			.endpoint(ENDPOINT)
+			.region(REGION)
+			.credentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY)
+			.build();
+
+		PresignedPostForm postForm = client.bucket(BUCKET)
+			.object(OBJECT_KEY)
+			.presignedPostForm()
+			.expiration(Duration.ofMinutes(30))
+			.maxFileSize(5 * 1024 * 1024) // 5MB
+			.field("Content-Type", "text/plain")
+			.field("Cache-Control", "max-age=3600")
+			.generate();
+
+		assertThat(postForm.formFields()).containsEntry("Content-Type", "text/plain");
+		assertThat(postForm.formFields()).containsEntry("Cache-Control", "max-age=3600");
+	}
+
+	@Test
+	void testPresignedPostFormWithDataSizeMaxFileSize() {
+		S3ClientConfiguration config = new S3ClientConfiguration(URI.create(ENDPOINT), REGION, ACCESS_KEY_ID,
+				SECRET_ACCESS_KEY);
+		S3Client client = S3Client.builder()
+			.endpoint(ENDPOINT)
+			.region(REGION)
+			.credentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY)
+			.build();
+
+		PresignedPostForm postForm = client.bucket(BUCKET)
+			.object(OBJECT_KEY)
+			.presignedPostForm()
+			.expiration(Duration.ofHours(1))
+			.maxFileSize(DataSize.ofMegabytes(20)) // 20MB using DataSize
+			.field("Content-Type", "application/json")
+			.generate();
+
+		assertThat(postForm.formFields()).containsKey("key");
+		assertThat(postForm.formFields()).containsKey("bucket");
+		assertThat(postForm.formFields()).containsEntry("Content-Type", "application/json");
+		assertThat(postForm.formFields()).containsValue(OBJECT_KEY);
+		assertThat(postForm.formFields()).containsValue(BUCKET);
+	}
+
+}

--- a/src/test/java/am/ik/s3/PresignedUrlIntegrationTest.java
+++ b/src/test/java/am/ik/s3/PresignedUrlIntegrationTest.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import am.ik.spring.logbook.AccessLoggerSink;
+import am.ik.spring.logbook.OpinionatedFilters;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.client.RestClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
+
+import static am.ik.s3.S3RequestBuilder.s3Request;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+@Testcontainers
+class PresignedUrlIntegrationTest {
+
+	private static final String ACCESS_KEY = "minioadmin";
+
+	private static final String SECRET_KEY = "minioadmin";
+
+	@Container
+	static GenericContainer<?> minio = new GenericContainer<>(DockerImageName.parse("minio/minio:latest"))
+		.withExposedPorts(9000)
+		.withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+		.withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+		.withCommand("server", "/data");
+
+	private S3Client client;
+
+	private RestClient restClient;
+
+	private static final String BUCKET_NAME = "test-bucket";
+
+	private static final String OBJECT_KEY = "test-object.txt";
+
+	private static final String TEST_CONTENT = "Hello, Presigned URL!";
+
+	@BeforeEach
+	void setUp() {
+		String endpoint = String.format("http://%s:%d", minio.getHost(), minio.getMappedPort(9000));
+
+		client = S3Client.builder().endpoint(endpoint).region("us-east-1").credentials(ACCESS_KEY, SECRET_KEY).build();
+
+		restClient = RestClient.builder()
+			.requestInterceptor(new LogbookClientHttpRequestInterceptor(Logbook.builder()
+				.sink(new AccessLoggerSink())
+				.headerFilter(OpinionatedFilters.headerFilter())
+				.build()))
+			.messageConverters(converters -> converters.add(new MappingJackson2XmlHttpMessageConverter()))
+			.build();
+
+		// Create test bucket
+		client.bucket(BUCKET_NAME).create();
+	}
+
+	@AfterEach
+	void tearDown() {
+		try {
+			// Clean up test object
+			client.bucket(BUCKET_NAME).object(OBJECT_KEY).delete();
+		}
+		catch (Exception e) {
+			// Ignore if object doesn't exist
+		}
+		try {
+			// Clean up test bucket
+			client.bucket(BUCKET_NAME).delete();
+		}
+		catch (Exception e) {
+			// Ignore if bucket doesn't exist
+		}
+	}
+
+	@Test
+	void testPresignedGetUrl() {
+		// First upload an object
+		client.bucket(BUCKET_NAME).object(OBJECT_KEY).put(TEST_CONTENT, MediaType.TEXT_PLAIN);
+
+		// Generate presigned GET URL
+		PresignedUrl getUrl = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(Duration.ofMinutes(15))
+			.forGet();
+
+		assertThat(getUrl.url()).isNotNull();
+		assertThat(getUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(getUrl.url().toString()).contains("X-Amz-Expires=900");
+		assertThat(getUrl.url().toString()).contains(BUCKET_NAME);
+		assertThat(getUrl.url().toString()).contains(OBJECT_KEY);
+		assertThat(getUrl.isExpired()).isFalse();
+
+		// Use the presigned URL to download the object
+		String downloadedContent = restClient.get()
+			.uri(getUrl.url())
+			.headers(getUrl.headers())
+			.retrieve()
+			.body(String.class);
+
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	@Test
+	void testPresignedPutUrl() {
+		// Generate presigned PUT URL without Content-Type header
+		PresignedUrl putUrl = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(Duration.ofMinutes(15))
+			.forPut();
+
+		assertThat(putUrl.url()).isNotNull();
+		assertThat(putUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(putUrl.url().toString()).contains("X-Amz-Expires=900");
+		assertThat(putUrl.url().toString()).contains(BUCKET_NAME);
+		assertThat(putUrl.url().toString()).contains(OBJECT_KEY);
+		assertThat(putUrl.isExpired()).isFalse();
+
+		// Use the presigned URL to upload content
+		restClient.put()
+			.uri(putUrl.url())
+			.headers(headers -> putUrl.requiredHeaders().forEach(headers::add))
+			.body(TEST_CONTENT)
+			.retrieve()
+			.toBodilessEntity();
+
+		// Verify the object was uploaded correctly
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	@Test
+	void testPresignedDeleteUrl() {
+		// First upload an object
+		client.bucket(BUCKET_NAME).object(OBJECT_KEY).put(TEST_CONTENT, MediaType.TEXT_PLAIN);
+
+		// Verify object exists
+		String content = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		assertThat(content).isEqualTo(TEST_CONTENT);
+
+		// Generate presigned DELETE URL
+		PresignedUrl deleteUrl = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(Duration.ofMinutes(15))
+			.forDelete();
+
+		assertThat(deleteUrl.url()).isNotNull();
+		assertThat(deleteUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(deleteUrl.url().toString()).contains("X-Amz-Expires=900");
+		assertThat(deleteUrl.url().toString()).contains(BUCKET_NAME);
+		assertThat(deleteUrl.url().toString()).contains(OBJECT_KEY);
+		assertThat(deleteUrl.isExpired()).isFalse();
+
+		// Use the presigned URL to delete the object
+		restClient.delete()
+			.uri(deleteUrl.url())
+			.headers(headers -> deleteUrl.requiredHeaders().forEach(headers::add))
+			.retrieve()
+			.toBodilessEntity();
+
+		// Verify the object was deleted
+		ListBucketResult listResult = client.bucket(BUCKET_NAME).listObjects();
+		assertThat(listResult.contents()).isNullOrEmpty();
+	}
+
+	@Test
+	void testPresignedPostForm() {
+		// Generate presigned POST form
+		PresignedPostForm postForm = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedPostForm()
+			.expiration(Duration.ofMinutes(15))
+			.maxFileSize(1024 * 1024) // 1MB
+			.field("Content-Type", "text/plain")
+			.generate();
+
+		assertThat(postForm.url()).isNotNull();
+		assertThat(postForm.url().toString()).contains(BUCKET_NAME);
+		assertThat(postForm.formFields()).containsKey("key");
+		assertThat(postForm.formFields()).containsKey("bucket");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Algorithm");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Credential");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Date");
+		assertThat(postForm.formFields()).containsKey("policy");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Signature");
+		assertThat(postForm.formFields()).containsEntry("Content-Type", "text/plain");
+		assertThat(postForm.formFields()).containsEntry("key", OBJECT_KEY);
+		assertThat(postForm.formFields()).containsEntry("bucket", BUCKET_NAME);
+
+		// Use the presigned POST form to upload content
+		restClient.post()
+			.uri(postForm.url())
+			.contentType(MediaType.MULTIPART_FORM_DATA)
+			.body(createMultipartFormData(postForm.formFields(), TEST_CONTENT))
+			.retrieve()
+			.toBodilessEntity();
+
+		// Verify the object was uploaded correctly
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	@Test
+	void testPresignedUrlWithCustomExpiration() {
+		// Upload an object first
+		client.bucket(BUCKET_NAME).object(OBJECT_KEY).put(TEST_CONTENT, MediaType.TEXT_PLAIN);
+
+		// Generate presigned URL with custom expiration
+		Duration customExpiration = Duration.ofHours(2);
+		PresignedUrl getUrl = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(customExpiration)
+			.forGet();
+
+		assertThat(getUrl.url().toString()).contains("X-Amz-Expires=7200"); // 2 hours =
+																			// 7200
+																			// seconds
+		assertThat(getUrl.url().toString()).contains(BUCKET_NAME);
+		assertThat(getUrl.url().toString()).contains(OBJECT_KEY);
+		assertThat(getUrl.isExpired()).isFalse();
+
+		// Use the presigned URL
+		String downloadedContent = restClient.get()
+			.uri(getUrl.url())
+			.headers(getUrl.headers())
+			.retrieve()
+			.body(String.class);
+
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	@Test
+	void testPresignedPostFormWithDataSize() {
+		// Generate presigned POST form with DataSize
+		PresignedPostForm postForm = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedPostForm()
+			.expiration(Duration.ofMinutes(15))
+			.maxFileSize(DataSize.ofMegabytes(5)) // 5MB using DataSize
+			.field("Content-Type", "text/plain")
+			.generate();
+
+		assertThat(postForm.url()).isNotNull();
+		assertThat(postForm.url().toString()).contains(BUCKET_NAME);
+		assertThat(postForm.formFields()).containsKey("key");
+		assertThat(postForm.formFields()).containsKey("bucket");
+		assertThat(postForm.formFields()).containsEntry("Content-Type", "text/plain");
+		assertThat(postForm.formFields()).containsEntry("key", OBJECT_KEY);
+		assertThat(postForm.formFields()).containsEntry("bucket", BUCKET_NAME);
+
+		// Use the presigned POST form to upload content
+		restClient.post()
+			.uri(postForm.url())
+			.contentType(MediaType.MULTIPART_FORM_DATA)
+			.body(createMultipartFormData(postForm.formFields(), TEST_CONTENT))
+			.retrieve()
+			.toBodilessEntity();
+
+		// Verify the object was uploaded correctly
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	@Test
+	void testPresignedUrlExpiration() throws InterruptedException {
+		// First upload an object
+		client.bucket(BUCKET_NAME).object(OBJECT_KEY).put(TEST_CONTENT, MediaType.TEXT_PLAIN);
+
+		// Generate presigned GET URL with 1 second expiration
+		PresignedUrl getUrl = client.bucket(BUCKET_NAME)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(Duration.ofSeconds(1))
+			.forGet();
+
+		assertThat(getUrl.url()).isNotNull();
+		assertThat(getUrl.isExpired()).isFalse();
+
+		// Use the presigned URL immediately - should work
+		String downloadedContent = restClient.get()
+			.uri(getUrl.url())
+			.headers(getUrl.headers())
+			.retrieve()
+			.body(String.class);
+
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+
+		// Wait for 2 seconds to ensure expiration
+		Thread.sleep(1000);
+
+		// Check that the URL is now expired
+		assertThat(getUrl.isExpired()).isTrue();
+
+		// Try to use the expired URL
+		var response = restClient.get()
+			.uri(getUrl.url())
+			.headers(getUrl.headers())
+			.retrieve()
+			.onStatus(stats -> stats.value() == 403, (req, res) -> {
+			})
+			.toEntity(String.class);
+		assertThat(response.getStatusCode()).isEqualTo(FORBIDDEN);
+		assertThat(response.getBody()).contains("Request has expired");
+	}
+
+	@Test
+	void testLowLevelApiPresignedUrl() {
+		// First upload an object using Fluent API
+		client.bucket(BUCKET_NAME).object(OBJECT_KEY).put(TEST_CONTENT, MediaType.TEXT_PLAIN);
+
+		// Generate presigned GET URL using Low Level API
+		String endpoint = String.format("http://%s:%d", minio.getHost(), minio.getMappedPort(9000));
+		S3Request request = s3Request().endpoint(URI.create(endpoint))
+			.region("us-east-1")
+			.accessKeyId(ACCESS_KEY)
+			.secretAccessKey(SECRET_KEY)
+			.method(GET)
+			.path(b -> b.bucket(BUCKET_NAME).key(OBJECT_KEY))
+			.build();
+
+		PresignedUrl presignedUrl = request.generatePresignedUrl(Duration.ofMinutes(15));
+
+		assertThat(presignedUrl.url()).isNotNull();
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Expires=900");
+		assertThat(presignedUrl.url().toString()).contains(BUCKET_NAME);
+		assertThat(presignedUrl.url().toString()).contains(OBJECT_KEY);
+		assertThat(presignedUrl.isExpired()).isFalse();
+
+		// Use the presigned URL to download the object
+		String downloadedContent = restClient.get()
+			.uri(presignedUrl.url())
+			.headers(presignedUrl.headers())
+			.retrieve()
+			.body(String.class);
+
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	@Test
+	void testLowLevelApiPresignedPostForm() {
+		// Generate presigned POST form using Low Level API
+		S3ClientConfiguration config = new S3ClientConfiguration(
+				URI.create(String.format("http://%s:%d", minio.getHost(), minio.getMappedPort(9000))), "us-east-1",
+				ACCESS_KEY, SECRET_KEY);
+
+		PresignedPostForm postForm = PresignedPostForm.builder(config, BUCKET_NAME, OBJECT_KEY)
+			.expiration(Duration.ofMinutes(15))
+			.maxFileSize(DataSize.ofMegabytes(1))
+			.field("Content-Type", "text/plain")
+			.generate();
+
+		assertThat(postForm.url()).isNotNull();
+		assertThat(postForm.url().toString()).contains(BUCKET_NAME);
+		assertThat(postForm.formFields()).containsKey("key");
+		assertThat(postForm.formFields()).containsKey("bucket");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Algorithm");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Credential");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Date");
+		assertThat(postForm.formFields()).containsKey("policy");
+		assertThat(postForm.formFields()).containsKey("X-Amz-Signature");
+		assertThat(postForm.formFields()).containsEntry("Content-Type", "text/plain");
+		assertThat(postForm.formFields()).containsEntry("key", OBJECT_KEY);
+		assertThat(postForm.formFields()).containsEntry("bucket", BUCKET_NAME);
+
+		// Use the presigned POST form to upload content
+		restClient.post()
+			.uri(postForm.url())
+			.contentType(MediaType.MULTIPART_FORM_DATA)
+			.body(createMultipartFormData(postForm.formFields(), TEST_CONTENT))
+			.retrieve()
+			.toBodilessEntity();
+
+		// Verify the object was uploaded correctly
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
+	}
+
+	private MultiValueMap<String, Object> createMultipartFormData(Map<String, String> formFields, String fileContent) {
+		MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+
+		// Add all form fields
+		formFields.forEach(parts::add);
+
+		// Add file content
+		ByteArrayResource fileResource = new ByteArrayResource(fileContent.getBytes()) {
+			@Override
+			public String getFilename() {
+				return OBJECT_KEY;
+			}
+		};
+		parts.add("file", fileResource);
+
+		return parts;
+	}
+
+}

--- a/src/test/java/am/ik/s3/PresignedUrlTest.java
+++ b/src/test/java/am/ik/s3/PresignedUrlTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+
+import static am.ik.s3.S3RequestBuilder.s3Request;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PresignedUrlTest {
+
+	private static final String ENDPOINT = "https://s3.amazonaws.com";
+
+	private static final String REGION = "us-east-1";
+
+	private static final String ACCESS_KEY_ID = "dummy-access-key";
+
+	private static final String SECRET_ACCESS_KEY = "dummy-secret-access-key";
+
+	private static final String BUCKET = "test-bucket";
+
+	private static final String OBJECT_KEY = "test-object.txt";
+
+	private static final Instant FIXED_TIME = Instant.parse("2023-12-25T12:00:00Z");
+
+	private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneId.of("UTC"));
+
+	@Test
+	void testPresignedUrlGeneration() {
+		S3Request request = s3Request().endpoint(URI.create(ENDPOINT))
+			.region(REGION)
+			.accessKeyId(ACCESS_KEY_ID)
+			.secretAccessKey(SECRET_ACCESS_KEY)
+			.method(HttpMethod.GET)
+			.path(b -> b.bucket(BUCKET).key(OBJECT_KEY))
+			.clock(FIXED_CLOCK)
+			.build();
+
+		Duration expiration = Duration.ofHours(1);
+		PresignedUrl presignedUrl = request.generatePresignedUrl(expiration);
+
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Credential=" + ACCESS_KEY_ID);
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Date=20231225T120000Z");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Expires=3600");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-SignedHeaders=host");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Signature=");
+		assertThat(presignedUrl.expiresAt()).isEqualTo(FIXED_TIME.plus(expiration));
+	}
+
+	@Test
+	void testPresignedUrlWithAdditionalHeaders() {
+		S3Request request = s3Request().endpoint(URI.create(ENDPOINT))
+			.region(REGION)
+			.accessKeyId(ACCESS_KEY_ID)
+			.secretAccessKey(SECRET_ACCESS_KEY)
+			.method(HttpMethod.PUT)
+			.path(b -> b.bucket(BUCKET).key(OBJECT_KEY))
+			.clock(FIXED_CLOCK)
+			.build();
+
+		Duration expiration = Duration.ofMinutes(30);
+		Map<String, String> headers = Map.of("Content-Type", "application/json");
+		PresignedUrl presignedUrl = request.generatePresignedUrl(expiration, headers);
+
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-SignedHeaders=content-type;host");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Expires=1800");
+		assertThat(presignedUrl.requiredHeaders()).containsEntry("Content-Type", "application/json");
+	}
+
+	@Test
+	void testPresignedUrlExpiration() {
+		Instant now = Instant.now();
+		Clock fixedClock = Clock.fixed(now, ZoneId.of("UTC"));
+
+		PresignedUrl expiredUrl = new PresignedUrl(URI.create("https://example.com"), now.minusSeconds(1), Map.of());
+		assertThat(expiredUrl.isExpired()).isTrue();
+		assertThat(expiredUrl.isExpired(fixedClock)).isTrue();
+
+		PresignedUrl validUrl = new PresignedUrl(URI.create("https://example.com"), now.plusSeconds(3600), Map.of());
+		assertThat(validUrl.isExpired()).isFalse();
+		assertThat(validUrl.isExpired(fixedClock)).isFalse();
+
+		// Test with a clock set to future time
+		Clock futureClock = Clock.fixed(now.plusSeconds(3700), ZoneId.of("UTC"));
+		assertThat(validUrl.isExpired(futureClock)).isTrue();
+	}
+
+	@Test
+	void testPresignedUrlBuilderWithS3Client() {
+		S3ClientConfiguration config = new S3ClientConfiguration(URI.create(ENDPOINT), REGION, ACCESS_KEY_ID,
+				SECRET_ACCESS_KEY);
+		S3Client client = S3Client.builder()
+			.endpoint(ENDPOINT)
+			.region(REGION)
+			.credentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY)
+			.build();
+
+		PresignedUrl getUrl = client.bucket(BUCKET)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(Duration.ofHours(2))
+			.forGet();
+
+		assertThat(getUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(getUrl.url().toString()).contains("X-Amz-Expires=7200");
+
+		PresignedUrl putUrl = client.bucket(BUCKET)
+			.object(OBJECT_KEY)
+			.presignedUrl()
+			.expiration(Duration.ofMinutes(15))
+			.contentType(MediaType.APPLICATION_JSON)
+			.forPut();
+
+		assertThat(putUrl.url().toString()).contains("X-Amz-Expires=900");
+		assertThat(putUrl.requiredHeaders()).containsEntry("Content-Type", "application/json");
+	}
+
+	@Test
+	void testPresignedUrlHeadersMethod() {
+		Map<String, String> headers = Map.of("Content-Type", "application/json", "x-amz-meta-test", "value");
+		PresignedUrl presignedUrl = new PresignedUrl(URI.create("https://example.com/test"),
+				Instant.now().plusSeconds(3600), headers);
+
+		HttpHeaders httpHeaders = new HttpHeaders();
+		presignedUrl.headers().accept(httpHeaders);
+
+		assertThat(httpHeaders).containsEntry("Content-Type", List.of("application/json"));
+		assertThat(httpHeaders).containsEntry("x-amz-meta-test", List.of("value"));
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add comprehensive presigned URL support for secure, time-limited access to S3 objects
- Add presigned POST form support for direct browser uploads
- Implement Builder pattern as inner classes with private constructors
- Add shared signing utilities to eliminate code duplication

## Features Added
- **PresignedUrl record** with expiration checking and convenience methods
- **PresignedPostForm record** for browser uploads with policy conditions
- **Builder pattern** implementation as static inner classes
- **Clock abstraction** for testable expiration logic
- **DataSize support** for maximum file size specification
- **Fluent API integration** for modern S3 operations
- **Low Level API support** for advanced use cases

## Test Coverage
- Unit tests for all core functionality
- Integration tests with Minio container
- Expiration testing with real timeouts
- Both API styles thoroughly tested

## API Examples

### Fluent API
```java
PresignedUrl getUrl = client.bucket("my-bucket")
    .object("hello.txt")
    .presignedUrl()
    .expiration(Duration.ofHours(2))
    .forGet();

PresignedPostForm postForm = client.bucket("my-bucket")
    .object("uploads/${filename}")
    .presignedPostForm()
    .expiration(Duration.ofHours(1))
    .maxFileSize(DataSize.ofMegabytes(10))
    .generate();
```

### Low Level API
```java
PresignedUrl presignedUrl = request.generatePresignedUrl(Duration.ofHours(1));
PresignedPostForm postForm = PresignedPostForm.builder(config, bucket, key)
    .expiration(Duration.ofHours(1))
    .maxFileSize(DataSize.ofMegabytes(10))
    .generate();
```

🤖 Generated with [Claude Code](https://claude.ai/code)