### PR TITLE
Refactor S3OperationBuilder methods to return void instead of boolean

### DIFF
--- a/src/main/java/am/ik/s3/S3OperationBuilder.java
+++ b/src/main/java/am/ik/s3/S3OperationBuilder.java
@@ -1,13 +1,11 @@
 package am.ik.s3;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
@@ -88,9 +86,8 @@ public class S3OperationBuilder {
 
 		/**
 		 * Creates the bucket.
-		 * @return true if the bucket was created successfully
 		 */
-		public boolean create() {
+		public void create() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -100,15 +97,12 @@ public class S3OperationBuilder {
 				.build();
 
 			restClient.put().uri(request.uri()).headers(request.headers()).retrieve().toBodilessEntity();
-
-			return true;
 		}
 
 		/**
 		 * Deletes the bucket.
-		 * @return true if the bucket was deleted successfully
 		 */
-		public boolean delete() {
+		public void delete() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -118,8 +112,6 @@ public class S3OperationBuilder {
 				.build();
 
 			restClient.delete().uri(request.uri()).headers(request.headers()).retrieve().toBodilessEntity();
-
-			return true;
 		}
 
 		/**
@@ -170,19 +162,17 @@ public class S3OperationBuilder {
 		/**
 		 * Puts (uploads) an object with string content.
 		 * @param content The content to upload
-		 * @return true if the object was uploaded successfully
 		 */
-		public boolean put(String content) {
-			return put(content, MediaType.TEXT_PLAIN);
+		public void put(String content) {
+			put(content, MediaType.TEXT_PLAIN);
 		}
 
 		/**
 		 * Puts (uploads) an object with string content and specified MIME type.
 		 * @param content The content to upload
 		 * @param mediaType The media type of the content
-		 * @return true if the object was uploaded successfully
 		 */
-		public boolean put(String content, MediaType mediaType) {
+		public void put(String content, MediaType mediaType) {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -192,25 +182,22 @@ public class S3OperationBuilder {
 				.content(S3Content.of(content, mediaType))
 				.build();
 			restClient.put().uri(request.uri()).headers(request.headers()).body(content).retrieve().toBodilessEntity();
-			return true;
 		}
 
 		/**
 		 * Puts (uploads) an object with byte array content.
 		 * @param content The content to upload
-		 * @return true if the object was uploaded successfully
 		 */
-		public boolean put(byte[] content) {
-			return put(content, MediaType.APPLICATION_OCTET_STREAM);
+		public void put(byte[] content) {
+			put(content, MediaType.APPLICATION_OCTET_STREAM);
 		}
 
 		/**
 		 * Puts (uploads) an object with byte array content and specified MIME type.
 		 * @param content The content to upload
 		 * @param mediaType The media type of the content
-		 * @return true if the object was uploaded successfully
 		 */
-		public boolean put(byte[] content, MediaType mediaType) {
+		public void put(byte[] content, MediaType mediaType) {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -220,18 +207,16 @@ public class S3OperationBuilder {
 				.content(S3Content.of(content, mediaType))
 				.build();
 			restClient.put().uri(request.uri()).headers(request.headers()).body(content).retrieve().toBodilessEntity();
-			return true;
 		}
 
 		/**
 		 * Puts (uploads) an object with InputStream content for streaming uploads.
 		 * @param inputStream The InputStream to upload
 		 * @param contentLength The length of the content in bytes
-		 * @return true if the object was uploaded successfully
 		 * @since 0.3.0
 		 */
-		public boolean putStream(InputStream inputStream, long contentLength) {
-			return putStream(inputStream, contentLength, MediaType.APPLICATION_OCTET_STREAM);
+		public void putStream(InputStream inputStream, long contentLength) {
+			putStream(inputStream, contentLength, MediaType.APPLICATION_OCTET_STREAM);
 		}
 
 		/**
@@ -240,10 +225,9 @@ public class S3OperationBuilder {
 		 * @param inputStream The InputStream to upload
 		 * @param contentLength The length of the content in bytes
 		 * @param mediaType The media type of the content
-		 * @return true if the object was uploaded successfully
 		 * @since 0.3.0
 		 */
-		public boolean putStream(InputStream inputStream, long contentLength, MediaType mediaType) {
+		public void putStream(InputStream inputStream, long contentLength, MediaType mediaType) {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -259,7 +243,6 @@ public class S3OperationBuilder {
 					return contentLength;
 				}
 			}).retrieve().toBodilessEntity();
-			return true;
 		}
 
 		/**
@@ -358,9 +341,8 @@ public class S3OperationBuilder {
 
 		/**
 		 * Deletes the object.
-		 * @return true if the object was deleted successfully
 		 */
-		public boolean delete() {
+		public void delete() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -369,7 +351,6 @@ public class S3OperationBuilder {
 				.path(b -> b.bucket(bucketName).key(objectKey))
 				.build();
 			restClient.delete().uri(request.uri()).headers(request.headers()).retrieve().toBodilessEntity();
-			return true;
 		}
 
 		/**

--- a/src/test/java/am/ik/s3/S3ClientIntegrationTest.java
+++ b/src/test/java/am/ik/s3/S3ClientIntegrationTest.java
@@ -65,8 +65,7 @@ class S3ClientIntegrationTest {
 		String bucketName = "test-bucket";
 
 		// Create bucket
-		boolean created = client.bucket(bucketName).create();
-		assertThat(created).isTrue();
+		client.bucket(bucketName).create();
 
 		// Verify bucket exists
 		ListBucketsResult result = client.listBuckets();
@@ -74,8 +73,7 @@ class S3ClientIntegrationTest {
 		assertThat(result.buckets().get(0).name()).isEqualTo(bucketName);
 
 		// Delete bucket
-		boolean deleted = client.bucket(bucketName).delete();
-		assertThat(deleted).isTrue();
+		client.bucket(bucketName).delete();
 
 		// Verify bucket is deleted
 		result = client.listBuckets();
@@ -92,8 +90,7 @@ class S3ClientIntegrationTest {
 		client.bucket(bucketName).create();
 
 		// Put object
-		boolean putResult = client.bucket(bucketName).object(objectKey).put(content);
-		assertThat(putResult).isTrue();
+		client.bucket(bucketName).object(objectKey).put(content);
 
 		// Get object
 		String retrievedContent = client.bucket(bucketName).object(objectKey).get();
@@ -114,8 +111,7 @@ class S3ClientIntegrationTest {
 		client.bucket(bucketName).create();
 
 		// Put object
-		boolean putResult = client.bucket(bucketName).object(objectKey).put(content);
-		assertThat(putResult).isTrue();
+		client.bucket(bucketName).object(objectKey).put(content);
 
 		// Get object as bytes
 		byte[] retrievedContent = client.bucket(bucketName).object(objectKey).getAsBytes();
@@ -168,8 +164,7 @@ class S3ClientIntegrationTest {
 		assertThat(result.contents()).hasSize(1);
 
 		// Delete object
-		boolean deleted = client.bucket(bucketName).object(objectKey).delete();
-		assertThat(deleted).isTrue();
+		client.bucket(bucketName).object(objectKey).delete();
 
 		// Verify object is deleted
 		result = client.bucket(bucketName).listObjects();

--- a/src/test/java/am/ik/s3/StreamingIntegrationTest.java
+++ b/src/test/java/am/ik/s3/StreamingIntegrationTest.java
@@ -83,10 +83,9 @@ class StreamingIntegrationTest {
 
 		// Upload using streaming PUT
 		try (InputStream inputStream = new ByteArrayInputStream(contentBytes)) {
-			boolean success = s3Client.bucket(bucketName)
+			s3Client.bucket(bucketName)
 				.object(objectKey)
 				.putStream(inputStream, contentBytes.length, MediaType.TEXT_PLAIN);
-			assertThat(success).isTrue();
 		}
 
 		// Download using streaming GET
@@ -133,8 +132,7 @@ class StreamingIntegrationTest {
 
 		// Upload using streaming PUT
 		try (InputStream inputStream = new ByteArrayInputStream(largeData)) {
-			boolean success = s3Client.bucket(bucketName).object(objectKey).putStream(inputStream, largeData.length);
-			assertThat(success).isTrue();
+			s3Client.bucket(bucketName).object(objectKey).putStream(inputStream, largeData.length);
 		}
 
 		// Download using streaming GET and verify


### PR DESCRIPTION
## Summary
- Changed `create()`, `delete()`, `put()`, and `putStream()` methods in S3OperationBuilder to return void
- These methods were always returning `true`, which served no meaningful purpose
- This change makes the API more intuitive and cleaner

## Changes
- Modified 9 methods in S3OperationBuilder.java to return void instead of boolean
- Updated all javadocs to remove @return tags for these methods
- Fixed test files that were asserting on the meaningless return values

## Test plan
- [x] All existing tests pass
- [x] Code has been formatted with Spring Java Format
- [x] No functional changes, only signature changes

🤖 Generated with [Claude Code](https://claude.ai/code)