### PR TITLE
Migrate from InputStream-based to Resource-based streaming API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,26 @@ System.out.println("Content: " + content); // Content: Hello World!
 byte[] imageData = client.bucket("my-bucket").object("test.png").getAsBytes();
 
 // Streaming operations for large files
-try (InputStream largeFileStream = Files.newInputStream(Paths.get("large-file.dat"))) {
-    long fileSize = Files.size(Paths.get("large-file.dat"));
-    client.bucket("my-bucket")
-        .object("large-file.dat")
-        .putStream(largeFileStream, fileSize);
-}
-
-// Download large files as stream
-try (InputStream downloadStream = client.bucket("my-bucket")
+Resource resource = new PathResource("large-file.dat");
+client.bucket("my-bucket")
     .object("large-file.dat")
-    .getAsStream()) {
+    .putResource(resource);
+
+// Download large files as Resource
+Resource downloadResource = client.bucket("my-bucket")
+    .object("large-file.dat")
+    .getAsResource();
+try (InputStream downloadStream = downloadResource.getInputStream()) {
     // Process stream without loading entire file into memory
     Files.copy(downloadStream, Paths.get("downloaded-file.dat"));
 }
 
 // Range requests for partial content
-try (InputStream partialStream = client.bucket("my-bucket")
+Resource partialResource = client.bucket("my-bucket")
     .object("large-file.dat")
     .range(1024, 2048)
-    .getAsStream()) {
+    .getAsResource();
+try (InputStream partialStream = partialResource.getInputStream()) {
     // Download only bytes 1024-2048
     byte[] partialData = partialStream.readAllBytes();
 }
@@ -133,20 +133,18 @@ CompleteMultipartUploadResult uploadResult = client.bucket("my-bucket")
     .upload(largeFileData);
 System.out.println("Large file uploaded: " + uploadResult.etag());
 
-// Multipart upload with InputStream
-try (FileInputStream fileInputStream = new FileInputStream("large-file.dat")) {
-    long fileSize = Files.size(Paths.get("large-file.dat"));
-    CompletableFuture<CompleteMultipartUploadResult> future = client.bucket("my-bucket")
-        .object("async-large-file.dat")
-        .multipartUpload()
-        .partSize(DataSize.ofMegabytes(5))
-        .maxConcurrentUploads(5)
-        .uploadAsync(fileInputStream, fileSize);
-    
-    // Continue with other work...
-    CompleteMultipartUploadResult result = future.get(); // Wait for completion
-    System.out.println("Async upload completed: " + result.etag());
-}
+// Multipart upload with Resource
+Resource resource = new PathResource("large-file.dat");
+CompletableFuture<CompleteMultipartUploadResult> future = client.bucket("my-bucket")
+    .object("async-large-file.dat")
+    .multipartUpload()
+    .partSize(DataSize.ofMegabytes(5))
+    .maxConcurrentUploads(5)
+    .uploadAsync(resource);
+
+// Continue with other work...
+CompleteMultipartUploadResult result = future.get(); // Wait for completion
+System.out.println("Async upload completed: " + result.etag());
 
 // Clean up
 client.bucket("my-bucket").object("hello.txt").delete();
@@ -165,6 +163,8 @@ Make sure the `RestTemplate` has `MappingJackson2XmlHttpMessageConverter` to con
 import static am.ik.s3.S3RequestBuilder.s3Request;
 
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.PathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -386,7 +386,10 @@ Make sure the `RestClient` has `MappingJackson2XmlHttpMessageConverter` to conve
 ```java
 import static am.ik.s3.S3RequestBuilder.s3Request;
 
+import java.nio.charset.StandardCharsets;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.PathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -478,42 +481,55 @@ S3Request rangeRequest = s3Request().endpoint(endpoint)
 	.path(b -> b.bucket(bucket).key("large-file.dat"))
 	.build()
 	.withRange(1024, 2048);
-	
-try (InputStream rangeStream = restClient.get()
+
+Resource rangeResource = restClient.get()
 	.uri(rangeRequest.uri())
 	.headers(rangeRequest.headers())
 	.retrieve()
-	.body(InputStream.class)) {
+	.body(Resource.class);
+try (InputStream rangeStream = rangeResource.getInputStream()) {
 	// Process partial content stream
 	byte[] partialData = rangeStream.readAllBytes();
 }
 
-// Streaming PUT with InputStream using S3Content.ofStream
-try (InputStream fileStream = Files.newInputStream(Paths.get("large-file.dat"))) {
-	long fileSize = Files.size(Paths.get("large-file.dat"));
-	S3Request putStreamRequest = s3Request().endpoint(endpoint)
-		.region(region)
-		.accessKeyId(accessKeyId)
-		.secretAccessKey(secretAccessKey)
-		.method(HttpMethod.PUT)
-		.path(b -> b.bucket(bucket).key("large-file.dat"))
-		.content(S3Content.ofStream(fileSize, MediaType.APPLICATION_OCTET_STREAM))
-		.build();
-	
-	restClient.put()
-		.uri(putStreamRequest.uri())
-		.headers(putStreamRequest.headers())
-		.body(new org.springframework.core.io.InputStreamResource(fileStream) {
-			@Override
-			public long contentLength() {
-				return fileSize;
-			}
-		})
-		.retrieve()
-		.toBodilessEntity();
-}
+// Streaming PUT with Resource from file using S3Content.ofResource
+Resource fileResource = new PathResource("large-file.dat");
+S3Request putStreamRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.PUT)
+	.path(b -> b.bucket(bucket).key("large-file.dat"))
+	.content(S3Content.ofResource(fileResource, MediaType.APPLICATION_OCTET_STREAM))
+	.build();
 
-// Streaming GET as InputStream
+restClient.put()
+	.uri(putStreamRequest.uri())
+	.headers(putStreamRequest.headers())
+	.body(fileResource)
+	.retrieve()
+	.toBodilessEntity();
+
+// Streaming PUT with Resource from byte array using S3Content.ofResource
+byte[] data = "This is test data for streaming upload".getBytes(StandardCharsets.UTF_8);
+Resource byteResource = new ByteArrayResource(data);
+S3Request putByteStreamRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.PUT)
+	.path(b -> b.bucket(bucket).key("stream-test.txt"))
+	.content(S3Content.ofResource(byteResource, MediaType.TEXT_PLAIN))
+	.build();
+
+restClient.put()
+	.uri(putByteStreamRequest.uri())
+	.headers(putByteStreamRequest.headers())
+	.body(byteResource)
+	.retrieve()
+	.toBodilessEntity();
+
+// Streaming GET as Resource
 S3Request getStreamRequest = s3Request().endpoint(endpoint)
 	.region(region)
 	.accessKeyId(accessKeyId)
@@ -522,11 +538,12 @@ S3Request getStreamRequest = s3Request().endpoint(endpoint)
 	.path(b -> b.bucket(bucket).key("large-file.dat"))
 	.build();
 
-try (InputStream downloadStream = restClient.get()
+Resource downloadResource = restClient.get()
 	.uri(getStreamRequest.uri())
 	.headers(getStreamRequest.headers())
 	.retrieve()
-	.body(InputStream.class)) {
+	.body(Resource.class);
+try (InputStream downloadStream = downloadResource.getInputStream()) {
 	// Process downloaded stream without loading entire file into memory
 	Files.copy(downloadStream, Paths.get("downloaded-file.dat"));
 }
@@ -729,13 +746,11 @@ try {
 - `.put(String content, MediaType mediaType)` - Upload string with specific media type
 - `.put(byte[] content)` - Upload binary content as application/octet-stream
 - `.put(byte[] content, MediaType mediaType)` - Upload binary with specific media type
-- `.putStream(InputStream, long contentLength)` - Upload from InputStream with known length
-- `.putStream(InputStream, long contentLength, MediaType)` - Upload from InputStream with specific media type
+- `.putResource(Resource)` - Upload from Spring Resource
+- `.putResource(Resource, MediaType)` - Upload from Spring Resource with specific media type
 - `.get()` - Download as string
 - `.getAsBytes()` - Download as byte array
-- `.getAsStream()` - Download as InputStream for streaming
-- `.getAsStream(long start, long end)` - Download specific byte range as InputStream
-- `.getAsStreamFrom(long start)` - Download from specific byte position as InputStream
+- `.getAsResource()` - Download as Spring Resource for streaming
 - `.delete()` - Delete the object
 
 #### Presigned URL Operations
@@ -761,15 +776,15 @@ try {
 - `.progressCallback(ProgressCallback)` - Set progress tracking callback
 - `.configuration(MultipartUploadConfiguration)` - Set custom configuration
 - `.upload(byte[])` - Upload data using multipart upload (synchronous)
-- `.upload(InputStream, long)` - Upload from input stream (synchronous)
+- `.upload(Resource)` - Upload from Spring Resource (synchronous)
 - `.uploadAsync(byte[])` - Upload data asynchronously
-- `.uploadAsync(InputStream, long)` - Upload from input stream asynchronously
+- `.uploadAsync(Resource)` - Upload from Spring Resource asynchronously
 
 #### Range Request Operations
 - `.range(long start, long end)` - Create range request builder for partial content retrieval
 - `.rangeFrom(long start)` - Create range request builder from specific position to end
 - Range request builder methods:
-  - `.getAsStream()` - Download partial content as InputStream
+  - `.getAsResource()` - Download partial content as Spring Resource
   - `.getAsBytes()` - Download partial content as byte array
   - `.get()` - Download partial content as string
 

--- a/src/main/java/am/ik/s3/MultipartUpload.java
+++ b/src/main/java/am/ik/s3/MultipartUpload.java
@@ -3,6 +3,9 @@ package am.ik.s3;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.client.RestClient;
 
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,50 +55,51 @@ public final class MultipartUpload {
 	 * @throws RuntimeException if the upload fails
 	 */
 	public CompleteMultipartUploadResult upload(byte[] data) {
-		return upload(new ByteArrayInputStream(data), data.length);
+		return upload(new ByteArrayResource(data));
 	}
 
 	/**
-	 * Uploads data from an input stream using multipart upload.
-	 * @param inputStream the input stream to read data from
-	 * @param contentLength the total length of the data
+	 * Uploads data from a Spring Resource using multipart upload.
+	 * @param resource the Spring Resource to read data from
 	 * @return the result of the completed multipart upload
 	 * @throws RuntimeException if the upload fails
 	 */
-	public CompleteMultipartUploadResult upload(InputStream inputStream, long contentLength) {
+	public CompleteMultipartUploadResult upload(Resource resource) {
 		try {
-			// Step 1: Initiate multipart upload
-			InitiateMultipartUploadResult initResult = initiateUpload();
-			String uploadId = initResult.uploadId();
+			long contentLength = resource.contentLength();
+			try (InputStream inputStream = resource.getInputStream()) {
+				// Step 1: Initiate multipart upload
+				InitiateMultipartUploadResult initResult = initiateUpload();
+				String uploadId = initResult.uploadId();
 
-			try {
-				// Step 2: Calculate parts and upload them
-				List<CompletedPart> completedParts = uploadParts(inputStream, contentLength, uploadId);
-
-				// Step 3: Complete multipart upload
-				CompleteMultipartUpload completeRequest = new CompleteMultipartUpload(completedParts);
-				CompleteMultipartUploadResult result = completeUpload(uploadId, completeRequest);
-
-				progressCallback.onUploadCompleted(contentLength);
-				return result;
-
-			}
-			catch (Exception e) {
-				// Abort the multipart upload on failure
 				try {
-					abortUpload(uploadId);
-				}
-				catch (Exception abortException) {
-					e.addSuppressed(abortException);
-				}
-				progressCallback.onError(e);
-				throw new RuntimeException("Multipart upload failed", e);
-			}
+					// Step 2: Calculate parts and upload them
+					List<CompletedPart> completedParts = uploadParts(inputStream, contentLength, uploadId);
 
+					// Step 3: Complete multipart upload
+					CompleteMultipartUpload completeRequest = new CompleteMultipartUpload(completedParts);
+					CompleteMultipartUploadResult result = completeUpload(uploadId, completeRequest);
+
+					progressCallback.onUploadCompleted(contentLength);
+					return result;
+
+				}
+				catch (Exception e) {
+					// Abort the multipart upload on failure
+					try {
+						abortUpload(uploadId);
+					}
+					catch (Exception abortException) {
+						e.addSuppressed(abortException);
+					}
+					progressCallback.onError(e);
+					throw new RuntimeException("Multipart upload failed", e);
+				}
+			}
 		}
-		catch (Exception e) {
+		catch (IOException e) {
 			progressCallback.onError(e);
-			throw new RuntimeException("Failed to initiate multipart upload", e);
+			throw new RuntimeException("Failed to read resource", e);
 		}
 	}
 
@@ -114,17 +118,16 @@ public final class MultipartUpload {
 	}
 
 	/**
-	 * Uploads data from an input stream using multipart upload asynchronously.
-	 * @param inputStream the input stream to read data from
-	 * @param contentLength the total length of the data
+	 * Uploads data from a Spring Resource using multipart upload asynchronously.
+	 * @param resource the Spring Resource to read data from
 	 * @return a CompletableFuture that will complete with the upload result
 	 */
-	public CompletableFuture<CompleteMultipartUploadResult> uploadAsync(InputStream inputStream, long contentLength) {
+	public CompletableFuture<CompleteMultipartUploadResult> uploadAsync(Resource resource) {
 		if (configuration.executor() != null) {
-			return CompletableFuture.supplyAsync(() -> upload(inputStream, contentLength), configuration.executor());
+			return CompletableFuture.supplyAsync(() -> upload(resource), configuration.executor());
 		}
 		else {
-			return CompletableFuture.supplyAsync(() -> upload(inputStream, contentLength));
+			return CompletableFuture.supplyAsync(() -> upload(resource));
 		}
 	}
 

--- a/src/main/java/am/ik/s3/S3Content.java
+++ b/src/main/java/am/ik/s3/S3Content.java
@@ -15,18 +15,18 @@
  */
 package am.ik.s3;
 
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 
 /**
  * Represents content to be sent in an S3 request. This is a sealed interface with two
- * implementations: - ByteArrayS3Content for in-memory content - StreamS3Content for
- * streaming content
+ * implementations: - ByteArrayS3Content for in-memory content - ResourceS3Content for
+ * Spring Resource based content
  *
  * @since 0.3.0
  */
-public sealed interface S3Content permits S3Content.ByteArrayS3Content, S3Content.StreamS3Content {
+public sealed interface S3Content permits S3Content.ByteArrayS3Content, S3Content.ResourceS3Content {
 
 	/**
 	 * Creates S3Content from a string.
@@ -49,24 +49,24 @@ public sealed interface S3Content permits S3Content.ByteArrayS3Content, S3Conten
 	}
 
 	/**
-	 * Creates streaming S3Content with content length and media type.
-	 * @param contentLength the length of the content in bytes
+	 * Creates resource-based S3Content with a Spring Resource and media type.
+	 * @param resource the Spring Resource containing the content
 	 * @param mediaType the media type of the content
-	 * @return a new StreamS3Content instance
+	 * @return a new ResourceS3Content instance
 	 * @since 0.3.0
 	 */
-	static S3Content ofStream(long contentLength, MediaType mediaType) {
-		return new StreamS3Content(contentLength, mediaType);
+	static S3Content ofResource(Resource resource, MediaType mediaType) {
+		return new ResourceS3Content(resource, mediaType);
 	}
 
 	/**
-	 * Creates streaming S3Content with content length and default media type.
-	 * @param contentLength the length of the content in bytes
-	 * @return a new StreamS3Content instance
+	 * Creates resource-based S3Content with a Spring Resource and default media type.
+	 * @param resource the Spring Resource containing the content
+	 * @return a new ResourceS3Content instance
 	 * @since 0.3.0
 	 */
-	static S3Content ofStream(long contentLength) {
-		return new StreamS3Content(contentLength, MediaType.APPLICATION_OCTET_STREAM);
+	static S3Content ofResource(Resource resource) {
+		return new ResourceS3Content(resource, MediaType.APPLICATION_OCTET_STREAM);
 	}
 
 	/**
@@ -79,14 +79,14 @@ public sealed interface S3Content permits S3Content.ByteArrayS3Content, S3Conten
 	}
 
 	/**
-	 * Represents streaming content to be sent in an S3 request. This allows for
-	 * memory-efficient uploads of large files.
+	 * Represents resource-based content to be sent in an S3 request. This allows for
+	 * direct use of Spring's Resource abstraction for file uploads.
 	 *
-	 * @param contentLength the length of the content in bytes
+	 * @param resource the Spring Resource containing the content
 	 * @param mediaType the media type of the content
 	 * @since 0.3.0
 	 */
-	record StreamS3Content(long contentLength, MediaType mediaType) implements S3Content {
+	record ResourceS3Content(Resource resource, MediaType mediaType) implements S3Content {
 	}
 
 }

--- a/src/main/java/am/ik/s3/S3OperationBuilder.java
+++ b/src/main/java/am/ik/s3/S3OperationBuilder.java
@@ -5,7 +5,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestClient;
@@ -210,39 +210,32 @@ public class S3OperationBuilder {
 		}
 
 		/**
-		 * Puts (uploads) an object with InputStream content for streaming uploads.
-		 * @param inputStream The InputStream to upload
-		 * @param contentLength The length of the content in bytes
+		 * Puts (uploads) an object with Resource content for streaming uploads.
+		 * @param resource The Spring Resource to upload
 		 * @since 0.3.0
 		 */
-		public void putStream(InputStream inputStream, long contentLength) {
-			putStream(inputStream, contentLength, MediaType.APPLICATION_OCTET_STREAM);
+		public void putResource(Resource resource) {
+			putResource(resource, MediaType.APPLICATION_OCTET_STREAM);
 		}
 
 		/**
-		 * Puts (uploads) an object with InputStream content and specified MIME type for
+		 * Puts (uploads) an object with Resource content and specified MIME type for
 		 * streaming uploads.
-		 * @param inputStream The InputStream to upload
-		 * @param contentLength The length of the content in bytes
+		 * @param resource The Spring Resource to upload
 		 * @param mediaType The media type of the content
 		 * @since 0.3.0
 		 */
-		public void putStream(InputStream inputStream, long contentLength, MediaType mediaType) {
+		public void putResource(Resource resource, MediaType mediaType) {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
 				.secretAccessKey(secretAccessKey)
 				.method(HttpMethod.PUT)
 				.path(b -> b.bucket(bucketName).key(objectKey))
-				.content(S3Content.ofStream(contentLength, mediaType))
+				.content(S3Content.ofResource(resource, mediaType))
 				.build();
 
-			restClient.put().uri(request.uri()).headers(request.headers()).body(new InputStreamResource(inputStream) {
-				@Override
-				public long contentLength() {
-					return contentLength;
-				}
-			}).retrieve().toBodilessEntity();
+			restClient.put().uri(request.uri()).headers(request.headers()).body(resource).retrieve().toBodilessEntity();
 		}
 
 		/**
@@ -276,11 +269,11 @@ public class S3OperationBuilder {
 		}
 
 		/**
-		 * Gets (downloads) an object as an InputStream for streaming.
-		 * @return The object content as an InputStream
+		 * Gets (downloads) an object as a Spring Resource for streaming.
+		 * @return The object content as a Spring Resource
 		 * @since 0.3.0
 		 */
-		public InputStream getAsStream() {
+		public Resource getAsResource() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -288,55 +281,7 @@ public class S3OperationBuilder {
 				.method(HttpMethod.GET)
 				.path(b -> b.bucket(bucketName).key(objectKey))
 				.build();
-			try {
-				org.springframework.core.io.Resource resource = restClient.get()
-					.uri(request.uri())
-					.headers(request.headers())
-					.retrieve()
-					.body(org.springframework.core.io.Resource.class);
-				return resource != null ? resource.getInputStream() : null;
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Failed to get stream", e);
-			}
-		}
-
-		/**
-		 * Gets (downloads) a portion of an object as an InputStream for streaming.
-		 * @param rangeStart the starting byte position (inclusive)
-		 * @param rangeEnd the ending byte position (inclusive)
-		 * @return The object content as an InputStream for the specified range
-		 * @since 0.3.0
-		 */
-		public InputStream getAsStream(long rangeStart, long rangeEnd) {
-			S3Request request = s3Request().endpoint(endpoint)
-				.region(region)
-				.accessKeyId(accessKeyId)
-				.secretAccessKey(secretAccessKey)
-				.method(HttpMethod.GET)
-				.path(b -> b.bucket(bucketName).key(objectKey))
-				.build()
-				.withRange(rangeStart, rangeEnd);
-			return restClient.get().uri(request.uri()).headers(request.headers()).retrieve().body(InputStream.class);
-		}
-
-		/**
-		 * Gets (downloads) an object starting from a specific byte position as an
-		 * InputStream for streaming.
-		 * @param rangeStart the starting byte position (inclusive)
-		 * @return The object content as an InputStream from the specified start position
-		 * @since 0.3.0
-		 */
-		public InputStream getAsStreamFrom(long rangeStart) {
-			S3Request request = s3Request().endpoint(endpoint)
-				.region(region)
-				.accessKeyId(accessKeyId)
-				.secretAccessKey(secretAccessKey)
-				.method(HttpMethod.GET)
-				.path(b -> b.bucket(bucketName).key(objectKey))
-				.build()
-				.withRangeFrom(rangeStart);
-			return restClient.get().uri(request.uri()).headers(request.headers()).retrieve().body(InputStream.class);
+			return restClient.get().uri(request.uri()).headers(request.headers()).retrieve().body(Resource.class);
 		}
 
 		/**
@@ -557,13 +502,12 @@ public class S3OperationBuilder {
 		}
 
 		/**
-		 * Uploads data from an input stream using multipart upload.
-		 * @param inputStream the input stream to read data from
-		 * @param contentLength the total length of the data
+		 * Uploads data from a Spring Resource using multipart upload.
+		 * @param resource the Spring Resource to read data from
 		 * @return the result of the completed multipart upload
 		 */
-		public CompleteMultipartUploadResult upload(InputStream inputStream, long contentLength) {
-			return createMultipartUpload().upload(inputStream, contentLength);
+		public CompleteMultipartUploadResult upload(Resource resource) {
+			return createMultipartUpload().upload(resource);
 		}
 
 		/**
@@ -576,14 +520,12 @@ public class S3OperationBuilder {
 		}
 
 		/**
-		 * Uploads data from an input stream using multipart upload asynchronously.
-		 * @param inputStream the input stream to read data from
-		 * @param contentLength the total length of the data
+		 * Uploads data from a Spring Resource using multipart upload asynchronously.
+		 * @param resource the Spring Resource to read data from
 		 * @return a CompletableFuture that will complete with the upload result
 		 */
-		public CompletableFuture<CompleteMultipartUploadResult> uploadAsync(InputStream inputStream,
-				long contentLength) {
-			return createMultipartUpload().uploadAsync(inputStream, contentLength);
+		public CompletableFuture<CompleteMultipartUploadResult> uploadAsync(Resource resource) {
+			return createMultipartUpload().uploadAsync(resource);
 		}
 
 		private MultipartUpload createMultipartUpload() {
@@ -621,10 +563,10 @@ public class S3OperationBuilder {
 		}
 
 		/**
-		 * Gets the partial content as an InputStream for streaming.
-		 * @return The partial object content as an InputStream
+		 * Gets the partial content as a Spring Resource for streaming.
+		 * @return The partial object content as a Spring Resource
 		 */
-		public InputStream getAsStream() {
+		public Resource getAsResource() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -636,17 +578,11 @@ public class S3OperationBuilder {
 			S3Request rangeRequest = rangeEnd != null ? request.withRange(rangeStart, rangeEnd)
 					: request.withRangeFrom(rangeStart);
 
-			try {
-				org.springframework.core.io.Resource resource = restClient.get()
-					.uri(rangeRequest.uri())
-					.headers(rangeRequest.headers())
-					.retrieve()
-					.body(org.springframework.core.io.Resource.class);
-				return resource != null ? resource.getInputStream() : null;
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Failed to get stream", e);
-			}
+			return restClient.get()
+				.uri(rangeRequest.uri())
+				.headers(rangeRequest.headers())
+				.retrieve()
+				.body(Resource.class);
 		}
 
 		/**

--- a/src/main/java/am/ik/s3/S3Request.java
+++ b/src/main/java/am/ik/s3/S3Request.java
@@ -137,12 +137,6 @@ public final class S3Request {
 					headers.put(HttpHeaders.CONTENT_TYPE, byteArrayContent.mediaType().toString());
 				}
 			}
-			else if (content instanceof S3Content.StreamS3Content streamContent) {
-				headers.put(HttpHeaders.CONTENT_LENGTH, String.valueOf(streamContent.contentLength()));
-				if (streamContent.mediaType() != null) {
-					headers.put(HttpHeaders.CONTENT_TYPE, streamContent.mediaType().toString());
-				}
-			}
 		}
 
 		// Add additional headers to the signing headers

--- a/src/test/java/am/ik/s3/MultipartUploadIntegrationTest.java
+++ b/src/test/java/am/ik/s3/MultipartUploadIntegrationTest.java
@@ -2,14 +2,16 @@ package am.ik.s3;
 
 import am.ik.spring.logbook.AccessLoggerSink;
 import am.ik.spring.logbook.OpinionatedFilters;
-import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.client.RestClient;
@@ -127,7 +129,7 @@ class MultipartUploadIntegrationTest {
 
 		// Create a 12MB file
 		byte[] data = createTestData(12 * 1024 * 1024);
-		ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+		ByteArrayResource resource = new ByteArrayResource(data);
 
 		// Perform multipart upload
 		CompleteMultipartUploadResult result = client.bucket(bucketName)
@@ -135,7 +137,7 @@ class MultipartUploadIntegrationTest {
 			.multipartUpload()
 			.partSize(DataSize.ofMegabytes(6))
 			.maxConcurrentUploads(1) // Sequential upload
-			.upload(inputStream, data.length);
+			.upload(resource);
 
 		// Verify the upload
 		assertThat(result).isNotNull();
@@ -307,7 +309,7 @@ class MultipartUploadIntegrationTest {
 		};
 
 		// Perform asynchronous multipart upload
-		java.util.concurrent.CompletableFuture<CompleteMultipartUploadResult> future = client.bucket(bucketName)
+		CompletableFuture<CompleteMultipartUploadResult> future = client.bucket(bucketName)
 			.object(objectKey)
 			.multipartUpload()
 			.partSize(DataSize.ofMegabytes(5))
@@ -350,7 +352,7 @@ class MultipartUploadIntegrationTest {
 		byte[] data = createTestData(8 * 1024 * 1024);
 
 		// Create custom executor
-		java.util.concurrent.ExecutorService customExecutor = java.util.concurrent.Executors.newFixedThreadPool(1);
+		ExecutorService customExecutor = java.util.concurrent.Executors.newFixedThreadPool(1);
 
 		try {
 			// Track progress
@@ -375,7 +377,7 @@ class MultipartUploadIntegrationTest {
 			};
 
 			// Perform asynchronous multipart upload with custom executor
-			java.util.concurrent.CompletableFuture<CompleteMultipartUploadResult> future = client.bucket(bucketName)
+			CompletableFuture<CompleteMultipartUploadResult> future = client.bucket(bucketName)
 				.object(objectKey)
 				.multipartUpload()
 				.partSize(DataSize.ofMegabytes(5))

--- a/src/test/java/am/ik/s3/StreamingIntegrationTest.java
+++ b/src/test/java/am/ik/s3/StreamingIntegrationTest.java
@@ -2,14 +2,15 @@ package am.ik.s3;
 
 import am.ik.spring.logbook.AccessLoggerSink;
 import am.ik.spring.logbook.OpinionatedFilters;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
@@ -77,21 +78,19 @@ class StreamingIntegrationTest {
 
 	@Test
 	void testStreamingGetAndPut() throws IOException {
-		String objectKey = "streaming-test.txt";
-		String content = "Hello, World! This is a streaming test.";
-		byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+		String objectKey = "streaming-test.png";
 
-		// Upload using streaming PUT
-		try (InputStream inputStream = new ByteArrayInputStream(contentBytes)) {
-			s3Client.bucket(bucketName)
-				.object(objectKey)
-				.putStream(inputStream, contentBytes.length, MediaType.TEXT_PLAIN);
-		}
+		// Upload using streaming PUT with ClassPathResource
+		Resource resource = new ClassPathResource("test.png");
+		s3Client.bucket(bucketName).object(objectKey).putResource(resource, MediaType.IMAGE_PNG);
 
 		// Download using streaming GET
-		try (InputStream downloadStream = s3Client.bucket(bucketName).object(objectKey).getAsStream()) {
+		Resource downloadResource = s3Client.bucket(bucketName).object(objectKey).getAsResource();
+		try (InputStream originalStream = resource.getInputStream();
+				InputStream downloadStream = downloadResource.getInputStream()) {
+			byte[] originalBytes = originalStream.readAllBytes();
 			byte[] downloadedBytes = downloadStream.readAllBytes();
-			assertThat(new String(downloadedBytes, StandardCharsets.UTF_8)).isEqualTo(content);
+			assertThat(downloadedBytes).isEqualTo(originalBytes);
 		}
 
 		// Clean up
@@ -107,13 +106,15 @@ class StreamingIntegrationTest {
 		s3Client.bucket(bucketName).object(objectKey).put(content, MediaType.TEXT_PLAIN);
 
 		// Test range request (bytes 10-19)
-		try (InputStream rangeStream = s3Client.bucket(bucketName).object(objectKey).range(10, 19).getAsStream()) {
+		Resource rangeResource = s3Client.bucket(bucketName).object(objectKey).range(10, 19).getAsResource();
+		try (InputStream rangeStream = rangeResource.getInputStream()) {
 			String rangeContent = new String(rangeStream.readAllBytes(), StandardCharsets.UTF_8);
 			assertThat(rangeContent).isEqualTo("ABCDEFGHIJ");
 		}
 
 		// Test range request from position (bytes 30 to end)
-		try (InputStream rangeStream = s3Client.bucket(bucketName).object(objectKey).rangeFrom(30).getAsStream()) {
+		Resource rangeFromResource = s3Client.bucket(bucketName).object(objectKey).rangeFrom(30).getAsResource();
+		try (InputStream rangeStream = rangeFromResource.getInputStream()) {
 			String rangeContent = new String(rangeStream.readAllBytes(), StandardCharsets.UTF_8);
 			assertThat(rangeContent).isEqualTo("UVWXYZ");
 		}
@@ -124,21 +125,19 @@ class StreamingIntegrationTest {
 
 	@Test
 	void testStreamingWithLargerData() throws IOException {
-		String objectKey = "large-streaming-test.dat";
-		byte[] largeData = new byte[1024 * 1024]; // 1MB
-		for (int i = 0; i < largeData.length; i++) {
-			largeData[i] = (byte) (i % 256);
-		}
+		String objectKey = "large-streaming-test.png";
 
-		// Upload using streaming PUT
-		try (InputStream inputStream = new ByteArrayInputStream(largeData)) {
-			s3Client.bucket(bucketName).object(objectKey).putStream(inputStream, largeData.length);
-		}
+		// Upload using streaming PUT with ClassPathResource
+		Resource resource = new ClassPathResource("test.png");
+		s3Client.bucket(bucketName).object(objectKey).putResource(resource);
 
 		// Download using streaming GET and verify
-		try (InputStream downloadStream = s3Client.bucket(bucketName).object(objectKey).getAsStream()) {
+		Resource downloadResource = s3Client.bucket(bucketName).object(objectKey).getAsResource();
+		try (InputStream originalStream = resource.getInputStream();
+				InputStream downloadStream = downloadResource.getInputStream()) {
+			byte[] originalData = originalStream.readAllBytes();
 			byte[] downloadedData = downloadStream.readAllBytes();
-			assertThat(downloadedData).isEqualTo(largeData);
+			assertThat(downloadedData).isEqualTo(originalData);
 		}
 
 		// Clean up
@@ -147,28 +146,25 @@ class StreamingIntegrationTest {
 
 	@Test
 	void testLowLevelStreamingOperations() throws IOException {
-		String objectKey = "low-level-streaming-test.txt";
-		String content = "This is a test for low-level streaming operations with RestClient.";
-		byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+		String objectKey = "low-level-streaming-test.png";
 
-		// Upload using low-level streaming PUT with S3Content.ofStream
-		try (InputStream inputStream = new ByteArrayInputStream(contentBytes)) {
-			S3Request putStreamRequest = s3Request().endpoint(endpoint)
-				.region("us-east-1")
-				.accessKeyId(accessKeyId)
-				.secretAccessKey(secretAccessKey)
-				.method(HttpMethod.PUT)
-				.path(b -> b.bucket(bucketName).key(objectKey))
-				.content(S3Content.ofStream(contentBytes.length, MediaType.TEXT_PLAIN))
-				.build();
+		// Upload using low-level streaming PUT with S3Content.ofResource
+		Resource uploadResource = new ClassPathResource("test.png");
+		S3Request putStreamRequest = s3Request().endpoint(endpoint)
+			.region("us-east-1")
+			.accessKeyId(accessKeyId)
+			.secretAccessKey(secretAccessKey)
+			.method(HttpMethod.PUT)
+			.path(b -> b.bucket(bucketName).key(objectKey))
+			.content(S3Content.ofResource(uploadResource, MediaType.IMAGE_PNG))
+			.build();
 
-			restClient.put()
-				.uri(putStreamRequest.uri())
-				.headers(putStreamRequest.headers())
-				.body(new InputStreamResource(inputStream))
-				.retrieve()
-				.toBodilessEntity();
-		}
+		restClient.put()
+			.uri(putStreamRequest.uri())
+			.headers(putStreamRequest.headers())
+			.body(uploadResource)
+			.retrieve()
+			.toBodilessEntity();
 
 		// Download using low-level streaming GET
 		S3Request getStreamRequest = s3Request().endpoint(endpoint)
@@ -179,18 +175,20 @@ class StreamingIntegrationTest {
 			.path(b -> b.bucket(bucketName).key(objectKey))
 			.build();
 
-		org.springframework.core.io.Resource resource = restClient.get()
+		Resource resource = restClient.get()
 			.uri(getStreamRequest.uri())
 			.headers(getStreamRequest.headers())
 			.retrieve()
-			.body(org.springframework.core.io.Resource.class);
+			.body(Resource.class);
 
-		try (InputStream downloadStream = resource.getInputStream()) {
+		try (InputStream originalStream = uploadResource.getInputStream();
+				InputStream downloadStream = Objects.requireNonNull(resource).getInputStream()) {
+			byte[] originalBytes = originalStream.readAllBytes();
 			byte[] downloadedBytes = downloadStream.readAllBytes();
-			assertThat(new String(downloadedBytes, StandardCharsets.UTF_8)).isEqualTo(content);
+			assertThat(downloadedBytes).isEqualTo(originalBytes);
 		}
 
-		// Test range request with low-level API
+		// Test range request with low-level API (first 100 bytes)
 		S3Request rangeRequest = s3Request().endpoint(endpoint)
 			.region("us-east-1")
 			.accessKeyId(accessKeyId)
@@ -198,20 +196,113 @@ class StreamingIntegrationTest {
 			.method(HttpMethod.GET)
 			.path(b -> b.bucket(bucketName).key(objectKey))
 			.build()
-			.withRange(5, 14);
+			.withRange(0, 99);
 
-		org.springframework.core.io.Resource rangeResource = restClient.get()
+		Resource rangeResource = restClient.get()
 			.uri(rangeRequest.uri())
 			.headers(rangeRequest.headers())
 			.retrieve()
-			.body(org.springframework.core.io.Resource.class);
+			.body(Resource.class);
 
-		try (InputStream rangeStream = rangeResource.getInputStream()) {
-			String rangeContent = new String(rangeStream.readAllBytes(), StandardCharsets.UTF_8);
-			assertThat(rangeContent).isEqualTo("is a test ");
+		try (InputStream originalStream = uploadResource.getInputStream();
+				InputStream rangeStream = Objects.requireNonNull(rangeResource).getInputStream()) {
+			byte[] originalBytes = originalStream.readAllBytes();
+			byte[] rangeBytes = rangeStream.readAllBytes();
+			assertThat(rangeBytes).hasSize(100);
+			assertThat(rangeBytes).isEqualTo(java.util.Arrays.copyOfRange(originalBytes, 0, 100));
 		}
 
 		// Clean up
+		s3Client.bucket(bucketName).object(objectKey).delete();
+	}
+
+	@Test
+	void testStreamingUploadWithPresignedUrlDownload() throws IOException {
+		String objectKey = "presigned-streaming-test.png";
+
+		// Upload using streaming PUT with ClassPathResource
+		Resource uploadResource = new ClassPathResource("test.png");
+		s3Client.bucket(bucketName).object(objectKey).putResource(uploadResource, MediaType.IMAGE_PNG);
+
+		// Generate presigned URL for download
+		PresignedUrl presignedUrl = s3Client.bucket(bucketName)
+			.object(objectKey)
+			.presignedUrl(HttpMethod.GET, java.time.Duration.ofMinutes(5));
+
+		assertThat(presignedUrl.url()).isNotNull();
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Signature=");
+
+		// Download using presigned URL with RestClient
+		Resource downloadedResource = restClient.get()
+			.uri(presignedUrl.url())
+			.headers(presignedUrl.headers())
+			.retrieve()
+			.body(Resource.class);
+
+		try (InputStream originalStream = uploadResource.getInputStream();
+				InputStream downloadStream = downloadedResource.getInputStream()) {
+			byte[] originalBytes = originalStream.readAllBytes();
+			byte[] downloadedBytes = downloadStream.readAllBytes();
+			assertThat(downloadedBytes).isEqualTo(originalBytes);
+		}
+
+		// Clean up
+		s3Client.bucket(bucketName).object(objectKey).delete();
+	}
+
+	@Test
+	void testLowLevelStreamingUploadWithPresignedUrlDownload() throws IOException {
+		String objectKey = "low-level-presigned-streaming-test.png";
+
+		// Upload using low-level streaming PUT with S3Content.ofResource
+		Resource uploadResource = new ClassPathResource("test.png");
+		S3Request putStreamRequest = s3Request().endpoint(endpoint)
+			.region("us-east-1")
+			.accessKeyId(accessKeyId)
+			.secretAccessKey(secretAccessKey)
+			.method(HttpMethod.PUT)
+			.path(b -> b.bucket(bucketName).key(objectKey))
+			.content(S3Content.ofResource(uploadResource, MediaType.IMAGE_PNG))
+			.build();
+
+		restClient.put()
+			.uri(putStreamRequest.uri())
+			.headers(putStreamRequest.headers())
+			.body(uploadResource)
+			.retrieve()
+			.toBodilessEntity();
+
+		// Generate presigned URL using low-level API
+		S3Request getRequest = s3Request().endpoint(endpoint)
+			.region("us-east-1")
+			.accessKeyId(accessKeyId)
+			.secretAccessKey(secretAccessKey)
+			.method(HttpMethod.GET)
+			.path(b -> b.bucket(bucketName).key(objectKey))
+			.build();
+
+		PresignedUrl presignedUrl = getRequest.presignedUrl(java.time.Duration.ofMinutes(5));
+
+		assertThat(presignedUrl.url()).isNotNull();
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+		assertThat(presignedUrl.url().toString()).contains("X-Amz-Signature=");
+
+		// Download using presigned URL with RestClient
+		Resource downloadedResource = restClient.get()
+			.uri(presignedUrl.url())
+			.headers(presignedUrl.headers())
+			.retrieve()
+			.body(Resource.class);
+
+		try (InputStream originalStream = uploadResource.getInputStream();
+				InputStream downloadStream = downloadedResource.getInputStream()) {
+			byte[] originalBytes = originalStream.readAllBytes();
+			byte[] downloadedBytes = downloadStream.readAllBytes();
+			assertThat(downloadedBytes).isEqualTo(originalBytes);
+		}
+
+		// Clean up using S3Client for convenience
 		s3Client.bucket(bucketName).object(objectKey).delete();
 	}
 


### PR DESCRIPTION
## Summary
- Migrate all streaming operations from InputStream-based to Resource-based API
- Remove deprecated S3Content.ofStream() methods and StreamS3Content record
- Update API methods: putStream() → putResource(), getAsStream() → getAsResource()
- Enhance test coverage with presigned URL integration tests using ClassPathResource

## Changes Made
### API Changes
- **Removed**: `S3Content.ofStream()` methods and `StreamS3Content` record
- **Updated**: `S3OperationBuilder.putStream()` → `putResource()`
- **Updated**: `S3OperationBuilder.getAsStream()` → `getAsResource()`  
- **Updated**: `MultipartUpload.upload(InputStream, long)` → `upload(Resource)`

### Documentation
- Added comprehensive Resource-based examples in README.md for both High-level and Low-level APIs
- Updated all code examples to use `S3Content.ofResource()`
- Added ByteArrayResource and PathResource usage examples

### Test Enhancements
- Updated all test code to use ByteArrayResource for better reusability
- Enhanced StreamingIntegrationTest with ClassPathResource("test.png") for realistic binary data testing
- Added new test methods for presigned URL integration with Resource-based streaming
- Added Low-level API version of presigned URL tests

## Benefits
- **Consistency**: All streaming operations now use Spring's Resource abstraction
- **Simplicity**: Single API approach eliminates confusion between InputStream and Resource methods
- **Flexibility**: Resource abstraction supports various input sources (files, classpath, byte arrays, URLs)
- **Better Testing**: More realistic test scenarios with actual binary files

## Test Coverage
All existing tests pass plus new comprehensive streaming integration tests:
- Basic Resource-based streaming operations
- Range requests with Resource
- Presigned URL generation and usage with Resource
- Low-level API streaming with Resource
- Multipart upload with Resource

🤖 Generated with [Claude Code](https://claude.ai/code)