### PR TITLE
Rename get() method to getAsString() for consistent naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ System.out.println(objects);
 client.bucket("my-bucket").object("hello.txt").put("Hello World!");
 client.bucket("my-bucket").object("test.png").put(imageBytes, MediaType.IMAGE_PNG);
 
-String content = client.bucket("my-bucket").object("hello.txt").get();
+String content = client.bucket("my-bucket").object("hello.txt").getAsString();
 System.out.println("Content: " + content); // Content: Hello World!
 
 byte[] imageData = client.bucket("my-bucket").object("test.png").getAsBytes();
@@ -748,7 +748,7 @@ try {
 - `.put(byte[] content, MediaType mediaType)` - Upload binary with specific media type
 - `.putResource(Resource)` - Upload from Spring Resource
 - `.putResource(Resource, MediaType)` - Upload from Spring Resource with specific media type
-- `.get()` - Download as string
+- `.getAsString()` - Download as string
 - `.getAsBytes()` - Download as byte array
 - `.getAsResource()` - Download as Spring Resource for streaming
 - `.delete()` - Delete the object
@@ -786,7 +786,7 @@ try {
 - Range request builder methods:
   - `.getAsResource()` - Download partial content as Spring Resource
   - `.getAsBytes()` - Download partial content as byte array
-  - `.get()` - Download partial content as string
+  - `.getAsString()` - Download partial content as string
 
 
 ### When to Use Which API

--- a/src/main/java/am/ik/s3/S3Client.java
+++ b/src/main/java/am/ik/s3/S3Client.java
@@ -25,7 +25,7 @@ import java.util.List;
  * client.bucket("my-bucket").object("file.txt").put("content");
  *
  * // Download object
- * String content = client.bucket("my-bucket").object("file.txt").get();
+ * String content = client.bucket("my-bucket").object("file.txt").getAsString();
  * }</pre>
  *
  * @since 0.3.0

--- a/src/main/java/am/ik/s3/S3OperationBuilder.java
+++ b/src/main/java/am/ik/s3/S3OperationBuilder.java
@@ -242,7 +242,7 @@ public class S3OperationBuilder {
 		 * Gets (downloads) an object as a string.
 		 * @return The object content as a string
 		 */
-		public String get() {
+		public String getAsString() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)
@@ -612,7 +612,7 @@ public class S3OperationBuilder {
 		 * Gets the partial content as a string.
 		 * @return The partial object content as a string
 		 */
-		public String get() {
+		public String getAsString() {
 			S3Request request = s3Request().endpoint(endpoint)
 				.region(region)
 				.accessKeyId(accessKeyId)

--- a/src/test/java/am/ik/s3/PresignedUrlIntegrationTest.java
+++ b/src/test/java/am/ik/s3/PresignedUrlIntegrationTest.java
@@ -154,7 +154,7 @@ class PresignedUrlIntegrationTest {
 			.toBodilessEntity();
 
 		// Verify the object was uploaded correctly
-		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).getAsString();
 		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
 	}
 
@@ -164,7 +164,7 @@ class PresignedUrlIntegrationTest {
 		client.bucket(BUCKET_NAME).object(OBJECT_KEY).put(TEST_CONTENT, MediaType.TEXT_PLAIN);
 
 		// Verify object exists
-		String content = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		String content = client.bucket(BUCKET_NAME).object(OBJECT_KEY).getAsString();
 		assertThat(content).isEqualTo(TEST_CONTENT);
 
 		// Generate presigned DELETE URL
@@ -223,7 +223,7 @@ class PresignedUrlIntegrationTest {
 			.toBodilessEntity();
 
 		// Verify the object was uploaded correctly
-		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).getAsString();
 		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
 	}
 
@@ -282,7 +282,7 @@ class PresignedUrlIntegrationTest {
 			.toBodilessEntity();
 
 		// Verify the object was uploaded correctly
-		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).getAsString();
 		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
 	}
 
@@ -400,7 +400,7 @@ class PresignedUrlIntegrationTest {
 			.toBodilessEntity();
 
 		// Verify the object was uploaded correctly
-		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).get();
+		String downloadedContent = client.bucket(BUCKET_NAME).object(OBJECT_KEY).getAsString();
 		assertThat(downloadedContent).isEqualTo(TEST_CONTENT);
 	}
 

--- a/src/test/java/am/ik/s3/S3ClientIntegrationTest.java
+++ b/src/test/java/am/ik/s3/S3ClientIntegrationTest.java
@@ -93,7 +93,7 @@ class S3ClientIntegrationTest {
 		client.bucket(bucketName).object(objectKey).put(content);
 
 		// Get object
-		String retrievedContent = client.bucket(bucketName).object(objectKey).get();
+		String retrievedContent = client.bucket(bucketName).object(objectKey).getAsString();
 		assertThat(retrievedContent).isEqualTo(content);
 
 		// Clean up
@@ -185,7 +185,7 @@ class S3ClientIntegrationTest {
 		client.bucket(bucketName).create();
 		client.bucket(bucketName).object(objectKey).put(content);
 
-		String retrievedContent = client.bucket(bucketName).object(objectKey).get();
+		String retrievedContent = client.bucket(bucketName).object(objectKey).getAsString();
 		assertThat(retrievedContent).isEqualTo(content);
 
 		// Clean up with fluent chaining


### PR DESCRIPTION
## Summary
- Renamed `get()` method to `getAsString()` in `ObjectOperationBuilder` and `RangeRequestBuilder`
- Updated all test files to use the new method name
- Updated README.md examples and API documentation
- Maintains consistency with existing `getAsBytes()` and `getAsResource()` methods

## Changes Made
- `S3OperationBuilder.java`: Renamed `ObjectOperationBuilder.get()` → `getAsString()`
- `S3OperationBuilder.java`: Renamed `RangeRequestBuilder.get()` → `getAsString()`
- `S3Client.java`: Updated javadoc example
- `S3ClientIntegrationTest.java`: Updated method calls
- `PresignedUrlIntegrationTest.java`: Updated method calls
- `README.md`: Updated examples and API documentation

## Test plan
- [x] All existing tests pass
- [x] Spring Java Format applied
- [x] No breaking changes to other get methods (getAsBytes, getAsResource)
- [x] Consistent naming convention across all get methods

🤖 Generated with [Claude Code](https://claude.ai/code)