### PR TITLE
Implement S3 object versioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,63 @@ CompletableFuture<CompleteMultipartUploadResult> future = client.bucket("my-buck
 CompleteMultipartUploadResult result = future.get(); // Wait for completion
 System.out.println("Async upload completed: " + result.etag());
 
+// Bucket versioning configuration
+// Enable versioning for a bucket
+client.bucket("my-bucket").enableVersioning();
+
+// Check versioning status
+VersioningConfiguration config = client.bucket("my-bucket").getVersioningConfiguration();
+System.out.println("Versioning enabled: " + config.isEnabled());
+
+// Suspend versioning
+client.bucket("my-bucket").suspendVersioning();
+
+// Set versioning configuration directly
+client.bucket("my-bucket").setVersioningConfiguration(VersioningConfiguration.enabled());
+
+// Object versioning operations
+// List all versions of an object
+ListVersionsResult versions = client.bucket("my-bucket")
+    .object("hello.txt")
+    .listVersions();
+System.out.println("Found " + versions.versions().size() + " versions");
+
+// Get a specific version
+String versionId = versions.versions().get(0).versionId();
+String versionedContent = client.bucket("my-bucket")
+    .object("hello.txt")
+    .version(versionId)
+    .getAsString();
+
+// Delete a specific version
+client.bucket("my-bucket")
+    .object("hello.txt")
+    .version(versionId)
+    .delete();
+
+// Copy a specific version to a new object
+client.bucket("my-bucket")
+    .object("hello.txt")
+    .version(versionId)
+    .copyTo("my-bucket", "hello-backup.txt");
+
+// Generate presigned URL for a specific version
+PresignedUrl versionUrl = client.bucket("my-bucket")
+    .object("hello.txt")
+    .version(versionId)
+    .presignedUrl(HttpMethod.GET, Duration.ofHours(1));
+
+// List all object versions in a bucket
+ListVersionsResult bucketVersions = client.bucket("my-bucket")
+    .listVersions();
+bucketVersions.versions().forEach(version -> {
+    System.out.println(version.key() + " - " + version.versionId() + 
+        " (Latest: " + version.isLatest() + ")");
+});
+bucketVersions.deleteMarkers().forEach(marker -> {
+    System.out.println(marker.key() + " - DELETE MARKER - " + marker.versionId());
+});
+
 // Clean up
 client.bucket("my-bucket").object("hello.txt").delete();
 client.bucket("my-bucket").object("test.png").delete();
@@ -320,6 +377,46 @@ S3Request verifyRequest = s3Request().endpoint(endpoint)
 	.build();
 String uploadedContent = restTemplate.exchange(verifyRequest.toEntityBuilder().build(), String.class).getBody();
 System.out.println("Uploaded content: " + uploadedContent);
+
+// Object versioning with RestTemplate
+// List object versions
+S3Request listVersionsRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.GET)
+	.path(b -> b.bucket(bucket))
+	.build()
+	.listVersions();
+ListVersionsResult versionsResult = restTemplate
+	.exchange(listVersionsRequest.toEntityBuilder().build(), ListVersionsResult.class)
+	.getBody();
+System.out.println("Found " + versionsResult.versions().size() + " versions");
+
+// Get specific version
+String versionId = versionsResult.versions().get(0).versionId();
+S3Request getVersionRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.GET)
+	.path(b -> b.bucket(bucket).key("hello.txt"))
+	.build()
+	.withVersionId(versionId);
+String versionedContent = restTemplate
+	.exchange(getVersionRequest.toEntityBuilder().build(), String.class)
+	.getBody();
+
+// Delete specific version
+S3Request deleteVersionRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.DELETE)
+	.path(b -> b.bucket(bucket).key("hello.txt"))
+	.build()
+	.deleteVersion(versionId);
+restTemplate.exchange(deleteVersionRequest.toEntityBuilder().build(), Void.class);
 
 // Multipart upload example with RestTemplate
 byte[] largeData = new byte[15 * 1024 * 1024]; // 15MB file
@@ -650,6 +747,54 @@ String uploadedContent = restClient.get()
 	.body(String.class);
 System.out.println("Uploaded content: " + uploadedContent);
 
+// Object versioning with RestClient
+// List object versions
+S3Request listVersionsRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.GET)
+	.path(b -> b.bucket(bucket))
+	.build()
+	.listVersions();
+ListVersionsResult versionsResult = restClient.get()
+	.uri(listVersionsRequest.uri())
+	.headers(listVersionsRequest.headers())
+	.retrieve()
+	.body(ListVersionsResult.class);
+System.out.println("Found " + versionsResult.versions().size() + " versions");
+
+// Get specific version
+String versionId = versionsResult.versions().get(0).versionId();
+S3Request getVersionRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.GET)
+	.path(b -> b.bucket(bucket).key("hello.txt"))
+	.build()
+	.withVersionId(versionId);
+String versionedContent = restClient.get()
+	.uri(getVersionRequest.uri())
+	.headers(getVersionRequest.headers())
+	.retrieve()
+	.body(String.class);
+
+// Delete specific version
+S3Request deleteVersionRequest = s3Request().endpoint(endpoint)
+	.region(region)
+	.accessKeyId(accessKeyId)
+	.secretAccessKey(secretAccessKey)
+	.method(HttpMethod.DELETE)
+	.path(b -> b.bucket(bucket).key("hello.txt"))
+	.build()
+	.deleteVersion(versionId);
+restClient.delete()
+	.uri(deleteVersionRequest.uri())
+	.headers(deleteVersionRequest.headers())
+	.retrieve()
+	.toBodilessEntity();
+
 // Multipart upload example with RestClient
 byte[] largeData = new byte[15 * 1024 * 1024]; // 15MB file
 Arrays.fill(largeData, (byte) 'A');
@@ -787,6 +932,19 @@ try {
   - `.getAsResource()` - Download partial content as Spring Resource
   - `.getAsBytes()` - Download partial content as byte array
   - `.getAsString()` - Download partial content as string
+
+#### Versioning Operations
+- `.listVersions()` - List all object versions in a bucket
+- `.listVersions(prefix, keyMarker, versionIdMarker, maxKeys)` - List versions with parameters
+- `.object(String).listVersions()` - List all versions of a specific object
+- `.object(String).version(String versionId)` - Select a specific version for operations
+- Version operation builder methods:
+  - `.getAsString()` - Download specific version as string
+  - `.getAsBytes()` - Download specific version as byte array
+  - `.getAsResource()` - Download specific version as Spring Resource
+  - `.delete()` - Delete specific version
+  - `.copyTo(String bucket, String key)` - Copy specific version to new location
+  - `.presignedUrl(HttpMethod, Duration)` - Generate presigned URL for specific version
 
 
 ### When to Use Which API

--- a/src/main/java/am/ik/s3/S3OperationBuilder.java
+++ b/src/main/java/am/ik/s3/S3OperationBuilder.java
@@ -1,6 +1,5 @@
 package am.ik.s3;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -132,6 +131,118 @@ public class S3OperationBuilder {
 				.headers(request.headers())
 				.retrieve()
 				.body(ListBucketResult.class);
+		}
+
+		/**
+		 * Lists object versions in the bucket.
+		 * @return ListVersionsResult containing the object versions in the bucket
+		 * @since 0.3.0
+		 */
+		public ListVersionsResult listVersions() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName))
+				.build()
+				.listVersions();
+
+			return restClient.get()
+				.uri(request.uri())
+				.headers(request.headers())
+				.retrieve()
+				.body(ListVersionsResult.class);
+		}
+
+		/**
+		 * Lists object versions in the bucket with parameters.
+		 * @param prefix the prefix to filter objects
+		 * @param keyMarker the key marker for pagination
+		 * @param versionIdMarker the version ID marker for pagination
+		 * @param maxKeys the maximum number of keys to return
+		 * @return ListVersionsResult containing the object versions in the bucket
+		 * @since 0.3.0
+		 */
+		public ListVersionsResult listVersions(String prefix, String keyMarker, String versionIdMarker,
+				Integer maxKeys) {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName))
+				.build()
+				.listVersions(prefix, keyMarker, versionIdMarker, maxKeys);
+
+			return restClient.get()
+				.uri(request.uri())
+				.headers(request.headers())
+				.retrieve()
+				.body(ListVersionsResult.class);
+		}
+
+		/**
+		 * Enables versioning for the bucket.
+		 * @since 0.3.0
+		 */
+		public void enableVersioning() {
+			setVersioningConfiguration(VersioningConfiguration.enabled());
+		}
+
+		/**
+		 * Suspends versioning for the bucket.
+		 * @since 0.3.0
+		 */
+		public void suspendVersioning() {
+			setVersioningConfiguration(VersioningConfiguration.suspended());
+		}
+
+		/**
+		 * Sets the versioning configuration for the bucket.
+		 * @param versioningConfiguration the versioning configuration to set
+		 * @since 0.3.0
+		 */
+		public void setVersioningConfiguration(VersioningConfiguration versioningConfiguration) {
+			String versioningConfigurationXml = versioningConfiguration.toXml();
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.PUT)
+				.path(b -> b.bucket(bucketName))
+				.canonicalQueryString("versioning=")
+				.content(S3Content.of(versioningConfigurationXml, MediaType.APPLICATION_XML))
+				.build();
+
+			restClient.put()
+				.uri(request.uri())
+				.headers(request.headers())
+				.body(versioningConfigurationXml)
+				.retrieve()
+				.toBodilessEntity();
+		}
+
+		/**
+		 * Gets the versioning configuration for the bucket.
+		 * @return the current versioning configuration
+		 * @since 0.3.0
+		 */
+		public VersioningConfiguration getVersioningConfiguration() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName))
+				.canonicalQueryString("versioning=")
+				.build();
+
+			return restClient.get()
+				.uri(request.uri())
+				.headers(request.headers())
+				.retrieve()
+				.body(VersioningConfiguration.class);
 		}
 
 		/**
@@ -406,6 +517,38 @@ public class S3OperationBuilder {
 			return new RangeRequestBuilder(bucketName, objectKey, rangeStart, null);
 		}
 
+		/**
+		 * Creates a version operation builder for a specific version of this object.
+		 * @param versionId the version ID of the object
+		 * @return a new VersionedObjectOperationBuilder instance
+		 * @since 0.3.0
+		 */
+		public VersionedObjectOperationBuilder version(String versionId) {
+			return new VersionedObjectOperationBuilder(bucketName, objectKey, versionId);
+		}
+
+		/**
+		 * Lists all versions of this object.
+		 * @return ListVersionsResult containing all versions of this object
+		 * @since 0.3.0
+		 */
+		public ListVersionsResult listVersions() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName))
+				.build()
+				.listVersions(objectKey, null, null, null);
+
+			return restClient.get()
+				.uri(request.uri())
+				.headers(request.headers())
+				.retrieve()
+				.body(ListVersionsResult.class);
+		}
+
 	}
 
 	/**
@@ -629,6 +772,139 @@ public class S3OperationBuilder {
 				.headers(rangeRequest.headers())
 				.retrieve()
 				.body(String.class);
+		}
+
+	}
+
+	/**
+	 * Builder class for version-specific object operations.
+	 *
+	 * @since 0.3.0
+	 */
+	public class VersionedObjectOperationBuilder {
+
+		private final String bucketName;
+
+		private final String objectKey;
+
+		private final String versionId;
+
+		private VersionedObjectOperationBuilder(String bucketName, String objectKey, String versionId) {
+			this.bucketName = bucketName;
+			this.objectKey = objectKey;
+			this.versionId = versionId;
+		}
+
+		/**
+		 * Gets (downloads) a specific version of an object as a string.
+		 * @return The versioned object content as a string
+		 */
+		public String getAsString() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName).key(objectKey))
+				.build()
+				.withVersionId(versionId);
+
+			return restClient.get().uri(request.uri()).headers(request.headers()).retrieve().body(String.class);
+		}
+
+		/**
+		 * Gets (downloads) a specific version of an object as a byte array.
+		 * @return The versioned object content as a byte array
+		 */
+		public byte[] getAsBytes() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName).key(objectKey))
+				.build()
+				.withVersionId(versionId);
+
+			return restClient.get().uri(request.uri()).headers(request.headers()).retrieve().body(byte[].class);
+		}
+
+		/**
+		 * Gets (downloads) a specific version of an object as a Spring Resource.
+		 * @return The versioned object content as a Spring Resource
+		 */
+		public Resource getAsResource() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.GET)
+				.path(b -> b.bucket(bucketName).key(objectKey))
+				.build()
+				.withVersionId(versionId);
+
+			return restClient.get().uri(request.uri()).headers(request.headers()).retrieve().body(Resource.class);
+		}
+
+		/**
+		 * Deletes a specific version of the object.
+		 */
+		public void delete() {
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.DELETE)
+				.path(b -> b.bucket(bucketName).key(objectKey))
+				.build()
+				.deleteVersion(versionId);
+
+			restClient.delete().uri(request.uri()).headers(request.headers()).retrieve().toBodilessEntity();
+		}
+
+		/**
+		 * Copies a specific version of this object to a new location.
+		 * @param destinationBucket the destination bucket name
+		 * @param destinationKey the destination object key
+		 */
+		public void copyTo(String destinationBucket, String destinationKey) {
+			String copySource = "/" + bucketName + "/" + objectKey + "?versionId=" + versionId;
+			Map<String, String> additionalHeaders = Map.of("x-amz-copy-source", copySource);
+
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(HttpMethod.PUT)
+				.path(b -> b.bucket(destinationBucket).key(destinationKey))
+				.additionalHeaders(additionalHeaders)
+				.build();
+
+			restClient.put().uri(request.uri()).headers(request.headers()).retrieve().toBodilessEntity();
+		}
+
+		/**
+		 * Generates a presigned URL for this specific version with the specified HTTP
+		 * method.
+		 * @param method the HTTP method (GET or DELETE)
+		 * @param expiration the duration until the URL expires
+		 * @return a PresignedUrl containing the URL and expiration information
+		 */
+		public PresignedUrl presignedUrl(HttpMethod method, java.time.Duration expiration) {
+			if (!(method == HttpMethod.GET || method == HttpMethod.DELETE)) {
+				throw new IllegalArgumentException("Method not supported for versioned objects: " + method);
+			}
+
+			S3Request request = s3Request().endpoint(endpoint)
+				.region(region)
+				.accessKeyId(accessKeyId)
+				.secretAccessKey(secretAccessKey)
+				.method(method)
+				.path(b -> b.bucket(bucketName).key(objectKey))
+				.build()
+				.withVersionId(versionId);
+
+			return request.presignedUrl(expiration);
 		}
 
 	}

--- a/src/main/java/am/ik/s3/S3Request.java
+++ b/src/main/java/am/ik/s3/S3Request.java
@@ -487,6 +487,113 @@ public final class S3Request {
 			.build();
 	}
 
+	/**
+	 * Creates a new S3Request for listing object versions in a bucket.
+	 * @return a new S3Request configured for listing object versions
+	 * @since 0.3.0
+	 */
+	public S3Request listVersions() {
+		return S3RequestBuilder.s3Request()
+			.endpoint(this.endpoint)
+			.region(this.region)
+			.accessKeyId(this.accessKeyId)
+			.secretAccessKey(this.secretAccessKey)
+			.method(HttpMethod.GET)
+			.path(b -> b.bucket(this.s3Path.bucket()))
+			.canonicalQueryString("versions=")
+			.build();
+	}
+
+	/**
+	 * Creates a new S3Request for listing object versions with parameters.
+	 * @param prefix the prefix to filter objects
+	 * @param keyMarker the key marker for pagination
+	 * @param versionIdMarker the version ID marker for pagination
+	 * @param maxKeys the maximum number of keys to return
+	 * @return a new S3Request configured for listing object versions
+	 * @since 0.3.0
+	 */
+	public S3Request listVersions(String prefix, String keyMarker, String versionIdMarker, Integer maxKeys) {
+		Map<String, String> params = new TreeMap<>();
+		params.put("versions", "");
+		if (prefix != null && !prefix.isEmpty()) {
+			params.put("prefix", urlEncode(prefix));
+		}
+		if (keyMarker != null && !keyMarker.isEmpty()) {
+			params.put("key-marker", urlEncode(keyMarker));
+		}
+		if (versionIdMarker != null && !versionIdMarker.isEmpty()) {
+			params.put("version-id-marker", urlEncode(versionIdMarker));
+		}
+		if (maxKeys != null) {
+			params.put("max-keys", String.valueOf(maxKeys));
+		}
+
+		String queryString = params.entrySet()
+			.stream()
+			.map(e -> e.getValue().isEmpty() ? e.getKey() + "=" : e.getKey() + "=" + e.getValue())
+			.collect(Collectors.joining("&"));
+
+		return S3RequestBuilder.s3Request()
+			.endpoint(this.endpoint)
+			.region(this.region)
+			.accessKeyId(this.accessKeyId)
+			.secretAccessKey(this.secretAccessKey)
+			.method(HttpMethod.GET)
+			.path(b -> b.bucket(this.s3Path.bucket()))
+			.canonicalQueryString(queryString)
+			.build();
+	}
+
+	/**
+	 * Creates a new S3Request for getting a specific version of an object.
+	 * @param versionId the version ID of the object
+	 * @return a new S3Request configured for getting a specific version
+	 * @since 0.3.0
+	 */
+	public S3Request withVersionId(String versionId) {
+		if (versionId == null || versionId.isEmpty()) {
+			throw new IllegalArgumentException("Version ID cannot be null or empty");
+		}
+
+		String queryString = this.canonicalQueryString.isEmpty() ? "versionId=" + urlEncode(versionId)
+				: this.canonicalQueryString + "&versionId=" + urlEncode(versionId);
+
+		return S3RequestBuilder.s3Request()
+			.endpoint(this.endpoint)
+			.region(this.region)
+			.accessKeyId(this.accessKeyId)
+			.secretAccessKey(this.secretAccessKey)
+			.method(this.method)
+			.path(b -> b.bucket(this.s3Path.bucket()).key(this.s3Path.key()))
+			.canonicalQueryString(queryString)
+			.content(this.content)
+			.additionalHeaders(this.additionalHeaders)
+			.build();
+	}
+
+	/**
+	 * Creates a new S3Request for deleting a specific version of an object.
+	 * @param versionId the version ID of the object to delete
+	 * @return a new S3Request configured for deleting a specific version
+	 * @since 0.3.0
+	 */
+	public S3Request deleteVersion(String versionId) {
+		if (versionId == null || versionId.isEmpty()) {
+			throw new IllegalArgumentException("Version ID cannot be null or empty");
+		}
+
+		return S3RequestBuilder.s3Request()
+			.endpoint(this.endpoint)
+			.region(this.region)
+			.accessKeyId(this.accessKeyId)
+			.secretAccessKey(this.secretAccessKey)
+			.method(HttpMethod.DELETE)
+			.path(b -> b.bucket(this.s3Path.bucket()).key(this.s3Path.key()))
+			.canonicalQueryString("versionId=" + urlEncode(versionId))
+			.build();
+	}
+
 	private String getCredentialScope(AmzDate amzDate) {
 		return "%s/%s/s3/aws4_request".formatted(amzDate.yymmdd(), this.region);
 	}

--- a/src/main/java/am/ik/s3/VersioningConfiguration.java
+++ b/src/main/java/am/ik/s3/VersioningConfiguration.java
@@ -1,0 +1,94 @@
+package am.ik.s3;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+/**
+ * Represents the versioning configuration for an S3 bucket. This record is used to enable
+ * or disable object versioning on a bucket.
+ *
+ * @param status The versioning status
+ * @since 0.3.0
+ */
+@JacksonXmlRootElement(localName = "VersioningConfiguration")
+public record VersioningConfiguration(@JacksonXmlProperty(localName = "Status") VersioningStatus status) {
+
+	public String toXml() {
+		return "<VersioningConfiguration><Status>%s</Status></VersioningConfiguration>".formatted(status.getValue());
+	}
+
+	/**
+	 * Creates a versioning configuration with versioning enabled.
+	 * @return A new VersioningConfiguration with status ENABLED
+	 */
+	public static VersioningConfiguration enabled() {
+		return new VersioningConfiguration(VersioningStatus.ENABLED);
+	}
+
+	/**
+	 * Creates a versioning configuration with versioning suspended.
+	 * @return A new VersioningConfiguration with status SUSPENDED
+	 */
+	public static VersioningConfiguration suspended() {
+		return new VersioningConfiguration(VersioningStatus.SUSPENDED);
+	}
+
+	/**
+	 * Enumeration representing the versioning status of an S3 bucket.
+	 *
+	 * @since 0.3.0
+	 */
+	public enum VersioningStatus {
+
+		/**
+		 * Versioning is enabled for the bucket.
+		 */
+		ENABLED("Enabled"),
+
+		/**
+		 * Versioning is suspended for the bucket.
+		 */
+		SUSPENDED("Suspended");
+
+		private final String value;
+
+		VersioningStatus(String value) {
+			this.value = value;
+		}
+
+		/**
+		 * Returns the string representation of the versioning status as used in S3 API.
+		 * @return the string value
+		 */
+		@JsonValue
+		public String getValue() {
+			return value;
+		}
+
+		/**
+		 * Returns the VersioningStatus enum from its string representation.
+		 * @param value the string value
+		 * @return the corresponding VersioningStatus enum
+		 * @throws IllegalArgumentException if the value is not recognized
+		 */
+		public static VersioningStatus fromValue(String value) {
+			if (value == null) {
+				return null;
+			}
+			for (VersioningStatus status : values()) {
+				if (status.value.equalsIgnoreCase(value)) {
+					return status;
+				}
+			}
+			throw new IllegalArgumentException("Unknown versioning status: " + value);
+		}
+
+		@Override
+		public String toString() {
+			return value;
+		}
+
+	}
+
+}

--- a/src/test/java/am/ik/s3/VersioningIntegrationTest.java
+++ b/src/test/java/am/ik/s3/VersioningIntegrationTest.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) 2023 Toshiaki Maki <makingx@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package am.ik.s3;
+
+import am.ik.spring.logbook.AccessLoggerSink;
+import am.ik.spring.logbook.OpinionatedFilters;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.ResourceHttpMessageConverter;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.spring.LogbookClientHttpRequestInterceptor;
+
+import static am.ik.s3.S3RequestBuilder.s3Request;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+/**
+ * Integration tests for S3 versioning features using LocalStack.
+ */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class VersioningIntegrationTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(VersioningIntegrationTest.class);
+
+	@Container
+	static LocalStackContainer localstack = new LocalStackContainer(
+			DockerImageName.parse("localstack/localstack:3.0.0"))
+		.withServices(S3);
+
+	private S3Client client;
+
+	private RestClient restClient;
+
+	private RestTemplate restTemplate;
+
+	private String bucket;
+
+	@BeforeEach
+	void setUp() {
+		Logbook logbook = Logbook.builder()
+			.sink(new AccessLoggerSink())
+			.headerFilter(OpinionatedFilters.headerFilter())
+			.build();
+
+		restClient = RestClient.builder()
+			.requestInterceptor(new LogbookClientHttpRequestInterceptor(logbook))
+			.messageConverters(converters -> {
+				converters.add(new MappingJackson2XmlHttpMessageConverter());
+				converters.add(new ResourceHttpMessageConverter());
+			})
+			.build();
+
+		restTemplate = new RestTemplate();
+		restTemplate.setInterceptors(List.of(new LogbookClientHttpRequestInterceptor(logbook)));
+		restTemplate.getMessageConverters().add(new MappingJackson2XmlHttpMessageConverter());
+
+		client = S3Client.builder()
+			.endpoint(localstack.getEndpointOverride(S3).toString())
+			.region(localstack.getRegion())
+			.credentials(localstack.getAccessKey(), localstack.getSecretKey())
+			.restClient(restClient)
+			.build();
+
+		bucket = "test-bucket-" + UUID.randomUUID();
+
+		// Create test bucket
+		client.bucket(bucket).create();
+		// Enable versioning on the bucket
+		client.bucket(bucket).enableVersioning();
+	}
+
+	@AfterEach
+	void tearDown() {
+		try {
+			// Delete all versions and delete markers
+			ListVersionsResult versions = client.bucket(bucket).listVersions();
+			if (versions.versions() != null) {
+				versions.versions().forEach(version -> {
+					if (version.versionId() != null && !version.versionId().equals("null")) {
+						client.bucket(bucket).object(version.key()).version(version.versionId()).delete();
+					}
+				});
+			}
+			if (versions.deleteMarkers() != null) {
+				versions.deleteMarkers().forEach(marker -> {
+					if (marker.versionId() != null && !marker.versionId().equals("null")) {
+						client.bucket(bucket).object(marker.key()).version(marker.versionId()).delete();
+					}
+				});
+			}
+			// Delete bucket
+			client.bucket(bucket).delete();
+		}
+		catch (Exception e) {
+			logger.warn("Failed to clean up test bucket", e);
+		}
+	}
+
+	@Test
+	void testListVersions() {
+		// Upload multiple versions of the same object
+		String key = "versioned-object.txt";
+		client.bucket(bucket).object(key).put("Version 1", MediaType.TEXT_PLAIN);
+		client.bucket(bucket).object(key).put("Version 2", MediaType.TEXT_PLAIN);
+		client.bucket(bucket).object(key).put("Version 3", MediaType.TEXT_PLAIN);
+
+		// List all versions
+		ListVersionsResult result = client.bucket(bucket).listVersions();
+		assertThat(result).isNotNull();
+		assertThat(result.name()).isEqualTo(bucket);
+		assertThat(result.versions()).hasSize(3);
+
+		// Verify versions are ordered from newest to oldest
+		List<Version> versions = result.versions();
+		assertThat(versions.get(0).key()).isEqualTo(key);
+		assertThat(versions.get(0).isLatest()).isTrue();
+		assertThat(versions.get(1).isLatest()).isFalse();
+		assertThat(versions.get(2).isLatest()).isFalse();
+
+		// Verify all versions have unique version IDs
+		List<String> versionIds = versions.stream().map(Version::versionId).collect(Collectors.toList());
+		assertThat(versionIds).doesNotHaveDuplicates();
+		assertThat(versionIds).allMatch(StringUtils::hasText);
+
+		logger.info("Version IDs: {}", versionIds);
+	}
+
+	@Test
+	void testListVersionsForSpecificObject() {
+		// Upload multiple objects
+		client.bucket(bucket).object("object1.txt").put("Content 1");
+		client.bucket(bucket).object("object2.txt").put("Content 2");
+		client.bucket(bucket).object("object1.txt").put("Content 1 Updated");
+
+		// List versions for a specific object
+		ListVersionsResult result = client.bucket(bucket).object("object1.txt").listVersions();
+		assertThat(result.versions()).hasSize(2);
+		assertThat(result.versions()).allMatch(v -> v.key().equals("object1.txt"));
+
+		// Verify version IDs are valid
+		assertThat(result.versions()).allMatch(v -> StringUtils.hasText(v.versionId()));
+	}
+
+	@Test
+	void testGetSpecificVersion() {
+		String key = "multi-version.txt";
+		// Upload multiple versions
+		client.bucket(bucket).object(key).put("Version 1", MediaType.TEXT_PLAIN);
+		client.bucket(bucket).object(key).put("Version 2", MediaType.TEXT_PLAIN);
+		client.bucket(bucket).object(key).put("Version 3", MediaType.TEXT_PLAIN);
+
+		// Get version IDs
+		ListVersionsResult versions = client.bucket(bucket).listVersions();
+		List<Version> versionList = versions.versions();
+		String latestVersionId = versionList.get(0).versionId();
+		String middleVersionId = versionList.get(1).versionId();
+		String oldestVersionId = versionList.get(2).versionId();
+
+		// Get specific versions
+		String latestContent = client.bucket(bucket).object(key).version(latestVersionId).getAsString();
+		String middleContent = client.bucket(bucket).object(key).version(middleVersionId).getAsString();
+		String oldestContent = client.bucket(bucket).object(key).version(oldestVersionId).getAsString();
+
+		assertThat(latestContent).isEqualTo("Version 3");
+		assertThat(middleContent).isEqualTo("Version 2");
+		assertThat(oldestContent).isEqualTo("Version 1");
+
+		// Verify that getting without version ID returns the latest
+		String currentContent = client.bucket(bucket).object(key).getAsString();
+		assertThat(currentContent).isEqualTo("Version 3");
+	}
+
+	@Test
+	void testDeleteSpecificVersion() {
+		String key = "delete-version-test.txt";
+		// Upload multiple versions
+		client.bucket(bucket).object(key).put("Version 1");
+		client.bucket(bucket).object(key).put("Version 2");
+		client.bucket(bucket).object(key).put("Version 3");
+
+		// Get version IDs
+		ListVersionsResult versions = client.bucket(bucket).listVersions();
+		String middleVersionId = versions.versions().get(1).versionId();
+
+		// Delete the middle version
+		client.bucket(bucket).object(key).version(middleVersionId).delete();
+
+		// Verify the version is deleted
+		ListVersionsResult afterDelete = client.bucket(bucket).listVersions();
+		assertThat(afterDelete.versions()).hasSize(2);
+		assertThat(afterDelete.versions()).noneMatch(v -> v.versionId().equals(middleVersionId));
+
+		// Verify other versions are still accessible
+		String latestContent = client.bucket(bucket).object(key).getAsString();
+		assertThat(latestContent).isEqualTo("Version 3");
+	}
+
+	@Test
+	void testDeleteMarkers() {
+		String key = "delete-marker-test.txt";
+		// Upload an object
+		client.bucket(bucket).object(key).put("Original content");
+
+		// Delete the object (creates a delete marker)
+		client.bucket(bucket).object(key).delete();
+
+		// Try to get the object - should fail
+		assertThatThrownBy(() -> client.bucket(bucket).object(key).getAsString()).isInstanceOf(Exception.class);
+
+		// List versions should show both the object and the delete marker
+		ListVersionsResult versions = client.bucket(bucket).listVersions();
+		assertThat(versions.versions()).hasSize(1);
+		assertThat(versions.deleteMarkers()).hasSize(1);
+		assertThat(versions.deleteMarkers().get(0).key()).isEqualTo(key);
+		assertThat(versions.deleteMarkers().get(0).isLatest()).isTrue();
+
+		// Delete the delete marker to restore the object
+		String deleteMarkerId = versions.deleteMarkers().get(0).versionId();
+		client.bucket(bucket).object(key).version(deleteMarkerId).delete();
+
+		// Now the object should be accessible again
+		String content = client.bucket(bucket).object(key).getAsString();
+		assertThat(content).isEqualTo("Original content");
+	}
+
+	@Test
+	void testVersionedCopy() {
+		String sourceKey = "source.txt";
+		String destKey = "destination.txt";
+
+		// Upload multiple versions
+		client.bucket(bucket).object(sourceKey).put("Version 1");
+		client.bucket(bucket).object(sourceKey).put("Version 2");
+
+		// Get the older version ID
+		ListVersionsResult versions = client.bucket(bucket).listVersions();
+		String olderVersionId = versions.versions().get(1).versionId();
+
+		// Copy the older version to a new object
+		client.bucket(bucket).object(sourceKey).version(olderVersionId).copyTo(bucket, destKey);
+
+		// Verify the copied content
+		String copiedContent = client.bucket(bucket).object(destKey).getAsString();
+		assertThat(copiedContent).isEqualTo("Version 1");
+	}
+
+	@Test
+	void testPresignedUrlWithVersion() {
+		String key = "presigned-version.txt";
+		// Upload multiple versions
+		client.bucket(bucket).object(key).put("Version 1");
+		client.bucket(bucket).object(key).put("Version 2");
+
+		// Get version IDs
+		ListVersionsResult versions = client.bucket(bucket).listVersions();
+		String olderVersionId = versions.versions().get(1).versionId();
+
+		// Generate presigned URL for the older version
+		PresignedUrl presignedUrl = client.bucket(bucket)
+			.object(key)
+			.version(olderVersionId)
+			.presignedUrl(HttpMethod.GET, Duration.ofMinutes(5));
+
+		// Use the presigned URL to get the content
+		String content = restClient.get().uri(presignedUrl.url()).retrieve().body(String.class);
+		assertThat(content).isEqualTo("Version 1");
+	}
+
+	@Test
+	void testVersioningWithLowLevelApi() {
+		String key = "low-level-version.txt";
+
+		// Upload multiple versions using low-level API
+		S3Request putRequest1 = s3Request().endpoint(localstack.getEndpointOverride(S3))
+			.region(localstack.getRegion())
+			.accessKeyId(localstack.getAccessKey())
+			.secretAccessKey(localstack.getSecretKey())
+			.method(HttpMethod.PUT)
+			.path(b -> b.bucket(bucket).key(key))
+			.content(S3Content.of("Low-level version 1", MediaType.TEXT_PLAIN))
+			.build();
+		restTemplate.exchange(putRequest1.toEntityBuilder().body("Low-level version 1"), Void.class);
+
+		S3Request putRequest2 = s3Request().endpoint(localstack.getEndpointOverride(S3))
+			.region(localstack.getRegion())
+			.accessKeyId(localstack.getAccessKey())
+			.secretAccessKey(localstack.getSecretKey())
+			.method(HttpMethod.PUT)
+			.path(b -> b.bucket(bucket).key(key))
+			.content(S3Content.of("Low-level version 2", MediaType.TEXT_PLAIN))
+			.build();
+		restTemplate.exchange(putRequest2.toEntityBuilder().body("Low-level version 2"), Void.class);
+
+		// List versions using low-level API
+		S3Request listVersionsRequest = s3Request().endpoint(localstack.getEndpointOverride(S3))
+			.region(localstack.getRegion())
+			.accessKeyId(localstack.getAccessKey())
+			.secretAccessKey(localstack.getSecretKey())
+			.method(HttpMethod.GET)
+			.path(b -> b.bucket(bucket))
+			.build()
+			.listVersions();
+
+		ListVersionsResult versionsResult = restTemplate
+			.exchange(listVersionsRequest.toEntityBuilder().build(), ListVersionsResult.class)
+			.getBody();
+
+		assertThat(versionsResult).isNotNull();
+		assertThat(versionsResult.versions()).hasSize(2);
+
+		// Get specific version using low-level API
+		String versionId = versionsResult.versions().get(1).versionId();
+		S3Request getVersionRequest = s3Request().endpoint(localstack.getEndpointOverride(S3))
+			.region(localstack.getRegion())
+			.accessKeyId(localstack.getAccessKey())
+			.secretAccessKey(localstack.getSecretKey())
+			.method(HttpMethod.GET)
+			.path(b -> b.bucket(bucket).key(key))
+			.build()
+			.withVersionId(versionId);
+
+		String versionContent = restTemplate.exchange(getVersionRequest.toEntityBuilder().build(), String.class)
+			.getBody();
+		assertThat(versionContent).isEqualTo("Low-level version 1");
+	}
+
+	@Test
+	void testVersioningWithBinaryContent() {
+		String key = "binary-version.dat";
+		byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
+		byte[] data2 = new byte[] { 6, 7, 8, 9, 10 };
+
+		// Upload binary versions
+		client.bucket(bucket).object(key).put(data1, MediaType.APPLICATION_OCTET_STREAM);
+		client.bucket(bucket).object(key).put(data2, MediaType.APPLICATION_OCTET_STREAM);
+
+		// Get version IDs
+		ListVersionsResult versions = client.bucket(bucket).listVersions();
+		String olderVersionId = versions.versions().get(1).versionId();
+
+		// Get specific version as bytes
+		byte[] olderData = client.bucket(bucket).object(key).version(olderVersionId).getAsBytes();
+		assertThat(olderData).isEqualTo(data1);
+
+		// Get latest version
+		byte[] latestData = client.bucket(bucket).object(key).getAsBytes();
+		assertThat(latestData).isEqualTo(data2);
+	}
+
+	@Test
+	void testListVersionsWithPagination() {
+		// Upload multiple objects to test pagination
+		for (int i = 0; i < 5; i++) {
+			String key = String.format("object-%02d.txt", i);
+			client.bucket(bucket).object(key).put("Content " + i);
+			client.bucket(bucket).object(key).put("Updated content " + i);
+		}
+
+		// List versions with max-keys limit
+		ListVersionsResult firstPage = client.bucket(bucket).listVersions(null, null, null, 3);
+		assertThat(firstPage.versions()).hasSize(3);
+		assertThat(firstPage.isTruncated()).isTrue();
+
+		// Get next page using markers
+		String nextKeyMarker = firstPage.versions().get(2).key();
+		String nextVersionIdMarker = firstPage.versions().get(2).versionId();
+		ListVersionsResult secondPage = client.bucket(bucket).listVersions(null, nextKeyMarker, nextVersionIdMarker, 3);
+		assertThat(secondPage.versions()).isNotEmpty();
+	}
+
+	@Test
+	void testVersioningConfiguration() {
+		// Create a new bucket for versioning configuration test
+		String testBucket = "versioning-config-test-" + UUID.randomUUID();
+		client.bucket(testBucket).create();
+
+		try {
+			// Initially, versioning should not be enabled
+			VersioningConfiguration config = client.bucket(testBucket).getVersioningConfiguration();
+			assertThat(config.status()).isNull();
+
+			// Enable versioning
+			client.bucket(testBucket).enableVersioning();
+
+			// Check that versioning is enabled
+			config = client.bucket(testBucket).getVersioningConfiguration();
+			assertThat(config.status()).isEqualTo(VersioningConfiguration.VersioningStatus.ENABLED);
+
+			// Suspend versioning
+			client.bucket(testBucket).suspendVersioning();
+
+			// Check that versioning is suspended
+			config = client.bucket(testBucket).getVersioningConfiguration();
+			assertThat(config.status()).isEqualTo(VersioningConfiguration.VersioningStatus.SUSPENDED);
+
+			// Test setting versioning configuration directly
+			client.bucket(testBucket).setVersioningConfiguration(VersioningConfiguration.enabled());
+			config = client.bucket(testBucket).getVersioningConfiguration();
+			assertThat(config.status()).isEqualTo(VersioningConfiguration.VersioningStatus.ENABLED);
+		}
+		finally {
+			// Clean up
+			try {
+				client.bucket(testBucket).delete();
+			}
+			catch (Exception e) {
+				logger.warn("Failed to clean up versioning configuration test bucket", e);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
Complete implementation of task **006-object-versioning.md** with comprehensive S3 object versioning support.

## 🎯 Fluent API for Bucket Versioning Configuration
- `client.bucket("my-bucket").enableVersioning()` - Enable versioning
- `client.bucket("my-bucket").suspendVersioning()` - Suspend versioning  
- `client.bucket("my-bucket").getVersioningConfiguration()` - Get current configuration
- `client.bucket("my-bucket").setVersioningConfiguration(config)` - Set custom configuration

## 📦 VersioningConfiguration Record
- `@JacksonXmlRootElement` annotation for XML serialization
- `VersioningStatus` inner enum with `ENABLED`/`SUSPENDED` values
- Factory methods: `enabled()`, `suspended()`
- `toXml()` method for efficient XML generation without XmlMapper dependency

## 🔄 Object Version Operations
- `client.bucket("bucket").object("key").listVersions()` - List all versions of an object
- `client.bucket("bucket").object("key").version("id").getAsString()` - Get specific version content
- `client.bucket("bucket").object("key").version("id").delete()` - Delete specific version
- `client.bucket("bucket").object("key").version("id").copyTo(bucket, key)` - Copy version to new location
- `client.bucket("bucket").object("key").version("id").presignedUrl(method, duration)` - Generate presigned URL

## 📋 Bucket Version Operations
- `client.bucket("bucket").listVersions()` - List all versions in bucket
- `client.bucket("bucket").listVersions(prefix, keyMarker, versionIdMarker, maxKeys)` - Paginated version listing

## 🔧 Low-Level API Support
- `S3Request.listVersions()` - Create list versions request
- `S3Request.withVersionId(versionId)` - Add version ID to request
- `S3Request.deleteVersion(versionId)` - Create delete version request

## 🧪 Comprehensive Test Coverage
- **LocalStack Integration**: All tests use LocalStack for real S3 compatibility
- **Version Management**: Create, list, retrieve, delete object versions
- **Delete Markers**: Handle delete markers and restoration
- **Bucket Configuration**: Enable/suspend versioning, get configuration status
- **Presigned URLs**: Generate presigned URLs for versioned objects
- **Binary Content**: Support for binary file versioning
- **Pagination**: Test version listing with pagination parameters

## Test plan
- [x] All versioning integration tests pass with LocalStack
- [x] Bucket versioning configuration (enable/suspend/get)
- [x] Object version operations (list/get/delete/copy)
- [x] Delete marker handling and restoration
- [x] Presigned URL generation for versioned objects
- [x] Binary content versioning support
- [x] Pagination support for version listing
- [x] Low-level API compatibility maintained
- [x] README documentation updated with examples

🤖 Generated with [Claude Code](https://claude.ai/code)